### PR TITLE
Allow email TOTP validation across sessions

### DIFF
--- a/public_html/src/Data/Repository/TOTPEmailRepository.php
+++ b/public_html/src/Data/Repository/TOTPEmailRepository.php
@@ -47,7 +47,7 @@ class TOTPEmailRepository
      *
      * @param int $userId
      * @param string $secret
-     * @return object|false The TOTP record if valid, null otherwise.
+     * @return object|false The TOTP record if valid, false otherwise.
      */
     public function findValidTOTP(int $userId, string $secret): object|false
     {
@@ -56,6 +56,21 @@ class TOTPEmailRepository
             ->where('totp_secret', $secret)
             ->where('expires_at', '>=', date('Y-m-d H:i:s'))
             ->first();
+    }
+
+    /**
+     * Find all valid TOTP secrets for the user that haven't expired.
+     *
+     * @param int $userId
+     * @return array
+     */
+    public function findAllValidTOTPs(int $userId): array
+    {
+        return $this->dbh->table('totp_email')
+            ->where('user_id', $userId)
+            ->where('expires_at', '>=', date('Y-m-d H:i:s'))
+            ->orderBy('created_at', 'DESC')
+            ->get();
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow email OTP verification to succeed even when the session that requested it is unavailable by checking all valid secrets for the user
- extend the query builder with ORDER BY and multi-record retrieval helpers used by the TOTP repository

## Testing
- php -l public_html/src/Data/QueryBuilder.php
- php -l public_html/src/Data/Repository/TOTPEmailRepository.php
- php -l public_html/src/Business/TOTPEmailService.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914af48f10083248a5e86375c12158f)