### PR TITLE
Regenerate session on successful login

### DIFF
--- a/public_html/app/Service/AuthService.php
+++ b/public_html/app/Service/AuthService.php
@@ -16,6 +16,7 @@ class AuthService
 
     public function loginUser(int $userId): void
     {
+        $this->session()->regenerate();
         $this->setAuthenticatedUserId($userId);
         $this->clearPendingAuthentication();
     }


### PR DESCRIPTION
### Motivation
- Prevent session fixation by regenerating the session id immediately when an authentication state change occurs.

### Description
- Call `SessionService::regenerate()` at the start of `AuthService::loginUser()` so the session id is rotated before storing authenticated state in the session (`public_html/app/Service/AuthService.php`).
- Keep `loginUserWithToken()` routing through `loginUser()` so all login code paths (including JWT-based logins) gain the session regeneration behavior.

### Testing
- Ran `php -l public_html/app/Service/AuthService.php` and it succeeded.
- Ran `php -l public_html/app/Service/SessionService.php` and it succeeded.
- Ran `cd public_html && composer validate --no-check-publish` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a60e8a8e33c8324aa3c059d1fd385b3)