### PR TITLE
Implement CSRF protection: middleware, service, Twig helpers, templates and tests

### DIFF
--- a/public_html/app/Middleware/Csrf.php
+++ b/public_html/app/Middleware/Csrf.php
@@ -1,0 +1,124 @@
+<?PHP
+
+declare(strict_types=1);
+
+namespace app\Middleware;
+
+use app\Container\Application;
+use app\Http\Request;
+use app\Http\Response;
+use app\Service\CsrfService;
+
+class Csrf
+{
+    protected Application $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    public function handle(Request $request, callable $next): Response
+    {
+        $csrf = $this->application->get('csrfService');
+        if ($csrf instanceof CsrfService === false) {
+            $csrf = new CsrfService($this->application->get('sessionService'));
+            $this->application->addService('csrfService', $csrf);
+        }
+
+        if ($csrf->isStateChangingMethod($request->getMethod()) === true && $csrf->isValidRequest($request) === false) {
+            return $this->reject($request);
+        }
+
+        return $next($request);
+    }
+
+    private function reject(Request $request): Response
+    {
+        $translation = $this->application->get('translationService');
+        $title = $translation->get('csrf-title');
+        $message = $translation->get('csrf-message');
+        $action = $translation->get('csrf-action');
+
+        if ($this->expectsJson($request) === true) {
+            return Response::json(
+                [
+                    'error' => 'csrf_token_invalid',
+                    'message' => $message,
+                    'action' => $action,
+                ],
+                419
+            );
+        }
+
+        $twig = $this->application->get('twig');
+        if ($twig instanceof \Twig\Environment) {
+            return Response::html(
+                $twig->render(
+                    'error/csrf.twig',
+                    [
+                        'csrfError' => [
+                            'title' => $title,
+                            'message' => $message,
+                            'action' => $action,
+                            'backUrl' => $this->getBackUrl($request),
+                        ],
+                    ]
+                ),
+                419
+            );
+        }
+
+        return Response::html(htmlspecialchars($message, ENT_QUOTES, 'UTF-8'), 419);
+    }
+
+    private function expectsJson(Request $request): bool
+    {
+        $accept = strtolower((string) $request->getHeader('Accept'));
+        $contentType = strtolower((string) $request->getHeader('Content-Type'));
+        $requestedWith = strtolower((string) $request->getHeader('X-Requested-With'));
+
+        return str_contains($accept, 'application/json') === true
+            || str_contains($contentType, 'application/json') === true
+            || $requestedWith === 'xmlhttprequest';
+    }
+
+    private function getBackUrl(Request $request): string
+    {
+        $referer = (string) ($request->getHeader('Referer') ?? '');
+        if ($referer !== '' && $this->isSameOrigin($referer, WEB_ROOT) === true) {
+            return $referer;
+        }
+
+        return WEB_ROOT;
+    }
+
+    private function isSameOrigin(string $url, string $origin): bool
+    {
+        $urlParts = parse_url($url);
+        $originParts = parse_url($origin);
+        if (is_array($urlParts) === false || is_array($originParts) === false) {
+            return false;
+        }
+
+        $urlScheme = strtolower((string) ($urlParts['scheme'] ?? ''));
+        $originScheme = strtolower((string) ($originParts['scheme'] ?? ''));
+        $urlHost = strtolower((string) ($urlParts['host'] ?? ''));
+        $originHost = strtolower((string) ($originParts['host'] ?? ''));
+
+        return $urlScheme !== ''
+            && $urlScheme === $originScheme
+            && $urlHost !== ''
+            && $urlHost === $originHost
+            && $this->normalizePort($urlParts, $urlScheme) === $this->normalizePort($originParts, $originScheme);
+    }
+
+    private function normalizePort(array $parts, string $scheme): int
+    {
+        if (isset($parts['port']) === true) {
+            return (int) $parts['port'];
+        }
+
+        return $scheme === 'https' ? 443 : 80;
+    }
+}

--- a/public_html/app/Middleware/Session.php
+++ b/public_html/app/Middleware/Session.php
@@ -27,6 +27,7 @@ class Session
     {
         $session = new \app\Service\SessionService($request);
         $this->application->addService('sessionService', $session);
+        $this->application->addService('csrfService', new \app\Service\CsrfService($session));
         $this->application->addService('authService', new \app\Service\AuthService($this->application));
         ini_set('session.save_handler', 'files');
         session_set_save_handler($session, true);

--- a/public_html/app/Middleware/Twig.php
+++ b/public_html/app/Middleware/Twig.php
@@ -33,6 +33,7 @@ class Twig
         $twig->addGlobal('docRoot', WEB_ROOT);
         $twig->addGlobal('assetVersion', $assetVersion);
         $twig->addExtension(new \app\Twig\TranslationExtension());
+        $twig->addExtension(new \app\Twig\CsrfExtension($this->application->get('csrfService')));
         $this->application->addService('twig', $twig);
         $response = $next($request);
         return $response;

--- a/public_html/app/Service/AuthService.php
+++ b/public_html/app/Service/AuthService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace app\Service;
 
 use app\Container\Application;
+use app\Service\CsrfService;
 use src\Business\UserService;
 use src\Entity\User;
 
@@ -19,6 +20,7 @@ class AuthService
         $this->session()->regenerate();
         $this->setAuthenticatedUserId($userId);
         $this->clearPendingAuthentication();
+        $this->rotateCsrfToken();
     }
 
     public function loginUserWithToken(int $userId, string $jwtToken): void
@@ -45,6 +47,8 @@ class AuthService
         if ($regenerateSession === true) {
             $this->session()->regenerate();
         }
+
+        $this->rotateCsrfToken();
     }
 
     public function getAuthenticatedUserId(): ?int
@@ -182,6 +186,14 @@ class AuthService
         }
 
         return $value;
+    }
+
+    public function rotateCsrfToken(): void
+    {
+        $csrf = $this->application->get('csrfService');
+        if ($csrf instanceof CsrfService) {
+            $csrf->rotateToken();
+        }
     }
 
     private function session(): SessionService

--- a/public_html/app/Service/CsrfService.php
+++ b/public_html/app/Service/CsrfService.php
@@ -1,0 +1,88 @@
+<?PHP
+
+declare(strict_types=1);
+
+namespace app\Service;
+
+use app\Http\Request;
+
+class CsrfService
+{
+    public const FIELD_NAME = '_csrf_token';
+    private const SESSION_KEY = '_csrf_token';
+
+    private SessionService $session;
+
+    public function __construct(SessionService $session)
+    {
+        $this->session = $session;
+    }
+
+    public function getToken(): string
+    {
+        $token = $this->session->get(self::SESSION_KEY);
+        if (is_string($token) === false || $token === '') {
+            return $this->rotateToken();
+        }
+
+        return $token;
+    }
+
+    public function rotateToken(): string
+    {
+        $token = $this->generateToken();
+        $this->session->set(self::SESSION_KEY, $token);
+
+        return $token;
+    }
+
+    public function getFieldName(): string
+    {
+        return self::FIELD_NAME;
+    }
+
+    public function renderInput(): string
+    {
+        return sprintf(
+            '<input type="hidden" name="%s" value="%s" />',
+            htmlspecialchars(self::FIELD_NAME, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->getToken(), ENT_QUOTES, 'UTF-8')
+        );
+    }
+
+    public function isValidRequest(Request $request): bool
+    {
+        $providedToken = $this->getSubmittedToken($request);
+
+        return is_string($providedToken) === true
+            && $providedToken !== ''
+            && hash_equals($this->getToken(), $providedToken);
+    }
+
+    public function isStateChangingMethod(string $method): bool
+    {
+        return in_array(strtoupper($method), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
+    }
+
+    private function getSubmittedToken(Request $request): mixed
+    {
+        $headerToken = $request->getHeader('X-CSRF-Token') ?? $request->getHeader('X-Csrf-Token') ?? $request->getHeader('x-csrf-token');
+        if (is_string($headerToken) === true && $headerToken !== '') {
+            return $headerToken;
+        }
+
+        $method = strtoupper($request->getMethod());
+        return match ($method) {
+            'POST' => $request->post(self::FIELD_NAME),
+            'PUT' => $request->put(self::FIELD_NAME),
+            'PATCH' => $request->patch(self::FIELD_NAME),
+            'DELETE' => $request->delete(self::FIELD_NAME),
+            default => null,
+        };
+    }
+
+    private function generateToken(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+}

--- a/public_html/app/Twig/CsrfExtension.php
+++ b/public_html/app/Twig/CsrfExtension.php
@@ -1,0 +1,33 @@
+<?PHP
+
+declare(strict_types=1);
+
+namespace app\Twig;
+
+use app\Service\CsrfService;
+use Twig\Extension\AbstractExtension;
+use Twig\Markup;
+use Twig\TwigFunction;
+
+class CsrfExtension extends AbstractExtension
+{
+    private CsrfService $csrf;
+
+    public function __construct(CsrfService $csrf)
+    {
+        $this->csrf = $csrf;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('csrf_token', [$this->csrf, 'getToken']),
+            new TwigFunction('csrf_field', [$this, 'csrfField'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function csrfField(): Markup
+    {
+        return new Markup($this->csrf->renderInput(), 'UTF-8');
+    }
+}

--- a/public_html/app/middleware.php
+++ b/public_html/app/middleware.php
@@ -9,14 +9,7 @@ $kernel->addMiddleware(
     }
 );
 
-$kernel->addMiddleware(
-    function ($request, $next) use ($app) {
-        $authSessionJwtMiddleware = $app->make(\app\Middleware\AuthSessionJWT::class);
-        return $authSessionJwtMiddleware->handle($request, $next);
-    }
-);
-
-// Locale depend on $_SESSION for now
+// Locale depends on $_SESSION for now.
 $kernel->addMiddleware(
     function ($request, $next) use ($app) {
         $localeMiddleware = $app->make(\app\Middleware\Locale::class);
@@ -24,10 +17,24 @@ $kernel->addMiddleware(
     }
 );
 
-// Mount twig to your kernel last, if possible
+// Mount Twig before CSRF so CSRF failures can render application-styled error pages.
 $kernel->addMiddleware(
     function ($request, $next) use ($app) {
         $twigMiddleware = $app->make(\app\Middleware\Twig::class);
         return $twigMiddleware->handle($request, $next);
+    }
+);
+
+$kernel->addMiddleware(
+    function ($request, $next) use ($app) {
+        $csrfMiddleware = $app->make(\app\Middleware\Csrf::class);
+        return $csrfMiddleware->handle($request, $next);
+    }
+);
+
+$kernel->addMiddleware(
+    function ($request, $next) use ($app) {
+        $authSessionJwtMiddleware = $app->make(\app\Middleware\AuthSessionJWT::class);
+        return $authSessionJwtMiddleware->handle($request, $next);
     }
 );

--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -322,6 +322,7 @@ class Account extends Controller
             $enabled = $this->mfaService->enableMfa($userId, $pendingSecret);
             if ($enabled === true) {
                 $auth->clearPendingMfaSetup();
+                $auth->rotateCsrfToken();
                 $this->accountMessages['success'][] = __('account.mfa-enabled');
             } else {
                 $this->accountMessages['errors'][] = __('account.mfa-enable-error');
@@ -356,6 +357,7 @@ class Account extends Controller
             $disabled = $this->mfaService->disableMfa($userId);
             if ($disabled === true) {
                 $auth->setPendingMfaSecret(null);
+                $auth->rotateCsrfToken();
                 $this->accountMessages['success'][] = __('account.mfa-disabled');
             } else {
                 $this->accountMessages['errors'][] = __('account.mfa-disable-error');

--- a/public_html/src/Controller/Logout.php
+++ b/public_html/src/Controller/Logout.php
@@ -13,6 +13,6 @@ class Logout extends Controller
     {
         $auth = $this->auth();
         $auth->logoutUser();
-        return Response::redirect(APP_BASE . '/login', 301);
+        return Response::redirect(APP_BASE . '/login', 303);
     }
 }

--- a/public_html/src/View/account.twig
+++ b/public_html/src/View/account.twig
@@ -11,13 +11,16 @@
             <div>
                 <h1 class="text-3xl font-bold">{{ __('account.headline') }}</h1>
             </div>
-            <a class="inline-flex shrink-0 items-center gap-2 rounded border border-gray-400 bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-200 dark:border-gray-600 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700" href="{{ docRoot }}logout" aria-label="{{ __('account.logout') }}">
-                <svg class="h-5 w-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v8" />
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.05 6.35a8 8 0 1 0 9.9 0" />
-                </svg>
-                <span>{{ __('account.logout') }}</span>
-            </a>
+            <form method="POST" action="{{ docRoot }}logout" class="shrink-0">
+                {{ csrf_field() }}
+                <button type="submit" class="inline-flex items-center gap-2 rounded border border-gray-400 bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-200 dark:border-gray-600 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700" aria-label="{{ __('account.logout') }}">
+                    <svg class="h-5 w-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v8" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M7.05 6.35a8 8 0 1 0 9.9 0" />
+                    </svg>
+                    <span>{{ __('account.logout') }}</span>
+                </button>
+            </form>
         </div>
 
         <div class="space-y-4 mb-6">
@@ -34,6 +37,7 @@
                 <h2 class="text-xl font-semibold mb-4">{{ __('account.change-username-title') }}</h2>
                 <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ __('account.current-username', { 'username': user.username }) }}</p>
                 <form method="POST" autocomplete="off" class="space-y-4">
+                    {{ csrf_field() }}
                     <div>
                         <label for="username" class="block text-sm font-medium">{{ __('account.new-username-label') }}</label>
                         <input type="text" name="username" id="username" value="{{ user.username }}" minlength="3" maxlength="32" pattern="[A-Za-z0-9._-]+"
@@ -52,6 +56,7 @@
                 <h2 class="text-xl font-semibold mb-4">{{ __('account.change-email-title') }}</h2>
                 <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ __('account.current-email', { 'email': user.email }) }}</p>
                 <form method="POST" autocomplete="off" class="space-y-4">
+                    {{ csrf_field() }}
                     <div>
                         <label for="new_email" class="block text-sm font-medium">{{ __('account.new-email-label') }}</label>
                         <input type="email" name="new_email" id="new_email" value="" class="field-input" required />
@@ -86,6 +91,7 @@
             <div class="mt-4 space-y-4">
                 {% if not mfa.enabled %}
                     <form method="POST">
+                        {{ csrf_field() }}
                         <button type="submit" name="submit_mfa_setup" value="1"
                             class="btn-secondary">
                             {{ __('account.mfa-start') }}
@@ -107,6 +113,7 @@
                             <p class="text-sm break-all">{{ __('account.mfa-otpauth-label') }}:<br><code class="font-mono">{{ mfa.otpauth|raw }}</code></p>
                         {% endif %}
                         <form method="POST" class="grid gap-4 md:grid-cols-2">
+                            {{ csrf_field() }}
                             <div>
                                 <label for="mfa_code" class="block text-sm font-medium">{{ __('account.mfa-code-label') }}</label>
                                 <input type="text" name="mfa_code" id="mfa_code" inputmode="numeric" pattern="\d*" maxlength="{{ mfa.digits }}"
@@ -166,6 +173,7 @@
                             </div>
 
                             <form method="POST" class="space-y-4">
+                                {{ csrf_field() }}
                                 <div>
                                     <label for="mfa_disable_code" class="block text-sm font-medium">{{ __('account.mfa-disable-code-label') }}</label>
                                     <input type="text" name="mfa_disable_code" id="mfa_disable_code" inputmode="numeric" pattern="\d*" maxlength="{{ mfa.digits }}"

--- a/public_html/src/View/error/csrf.twig
+++ b/public_html/src/View/error/csrf.twig
@@ -1,0 +1,17 @@
+{% extends "tmpl/base.twig" %}
+
+{% block md %}
+    <title>{{ csrfError.title }} - GangsterClub.com</title>
+{% endblock %}
+
+{% block content %}
+    <section class="relative flex min-h-screen items-center justify-center px-6 py-24 text-gray-700 dark:text-gray-200">
+        <div class="page-backdrop"></div>
+        <div class="panel panel-feature relative z-10 w-full max-w-xl text-center">
+            <p class="mb-2 text-xs font-bold uppercase tracking-[0.35em] text-gray-500 dark:text-gray-400">419</p>
+            <h1 class="mb-4 text-3xl font-extrabold">{{ csrfError.title }}</h1>
+            <p class="mb-6 text-sm text-gray-500 dark:text-gray-400">{{ csrfError.message }}</p>
+            <a class="btn-primary w-full" href="{{ csrfError.backUrl }}">{{ csrfError.action }}</a>
+        </div>
+    </section>
+{% endblock %}

--- a/public_html/src/View/partial/auth-entry.twig
+++ b/public_html/src/View/partial/auth-entry.twig
@@ -2,15 +2,18 @@
 {% import "macro/alerts.twig" as alerts %}
 
 {% if (uUID or UID) %}
-    <a class="absolute right-0 z-20 m-5 inline-flex items-center gap-2 rounded border border-gray-400 bg-gray-100 px-4 py-2 font-semibold text-gray-700 shadow-sm hover:bg-gray-200 dark:border-gray-600 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700" href="{{ docRoot }}logout" aria-label="Logout">
-        {% if authEntry.showLogoutIcon %}
-            <svg class="h-5 w-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v8" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M7.05 6.35a8 8 0 1 0 9.9 0" />
-            </svg>
-        {% endif %}
-        <span>Logout</span>
-    </a>
+    <form method="POST" action="{{ docRoot }}logout" class="absolute right-0 z-20 m-5">
+        {{ csrf_field() }}
+        <button type="submit" class="inline-flex items-center gap-2 rounded border border-gray-400 bg-gray-100 px-4 py-2 font-semibold text-gray-700 shadow-sm hover:bg-gray-200 dark:border-gray-600 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700" aria-label="Logout">
+            {% if authEntry.showLogoutIcon %}
+                <svg class="h-5 w-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v8" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.05 6.35a8 8 0 1 0 9.9 0" />
+                </svg>
+            {% endif %}
+            <span>Logout</span>
+        </button>
+    </form>
 {% endif %}
 <section class="flex flex-col md:flex-row h-screen">
     <div class="bg-transparent flex w-full h-full md:w-1/2 xl:w-3/4 items-center justify-center">
@@ -20,6 +23,7 @@
 
         <div class="w-full h-100">
             <form class="mt-6 auth-step auth-step-fade" method="POST" autocomplete="off">
+                {{ csrf_field() }}
                 {% for error in authEntry.flash.errors %}
                     {{ alerts.error(error) }}
                 {% endfor %}

--- a/public_html/src/resources/lang/de/messages.yaml
+++ b/public_html/src/resources/lang/de/messages.yaml
@@ -4,3 +4,6 @@ goodbye: "Auf Wiedersehen, :name!"
 "Hello, you didn't provide a name.": "Hallo, Sie haben keinen Namen angegeben."
 visitor: besucher
 pal: freund
+csrf-title: "Page expired"
+csrf-message: "This page or form expired. Please refresh the page or return to the form, then try again. Your action was not submitted."
+csrf-action: "Return and try again"

--- a/public_html/src/resources/lang/en/messages.yaml
+++ b/public_html/src/resources/lang/en/messages.yaml
@@ -4,3 +4,6 @@ goodbye: "Goodbye, :name!"
 "Hello, you didn't provide a name.": "Hello, you didn't provide a name."
 visitor: visitor
 pal: pal
+csrf-title: "Page expired"
+csrf-message: "This page or form expired. Please refresh the page or return to the form, then try again. Your action was not submitted."
+csrf-action: "Return and try again"

--- a/public_html/src/resources/lang/fr/messages.yaml
+++ b/public_html/src/resources/lang/fr/messages.yaml
@@ -4,3 +4,6 @@ goodbye: "Au revoir, :name!"
 "Hello, you didn't provide a name.": "Bonjour, vous n'avez pas fourni de nom."
 visitor: visiteur
 pal: ami
+csrf-title: "Page expired"
+csrf-message: "This page or form expired. Please refresh the page or return to the form, then try again. Your action was not submitted."
+csrf-action: "Return and try again"

--- a/public_html/src/resources/lang/nl/messages.yaml
+++ b/public_html/src/resources/lang/nl/messages.yaml
@@ -4,3 +4,6 @@ goodbye: "Tot ziens, :name!"
 "Hello, you didn't provide a name.": "Hallo, u hebt geen naam opgegeven."
 visitor: bezoeker
 pal: maat
+csrf-title: "Page expired"
+csrf-message: "This page or form expired. Please refresh the page or return to the form, then try again. Your action was not submitted."
+csrf-action: "Return and try again"

--- a/public_html/src/resources/routes.yaml
+++ b/public_html/src/resources/routes.yaml
@@ -32,4 +32,4 @@ accountVerifyEmail:
 logout:
     path: /logout
     controller: Logout
-    methods: ['GET', 'HEAD']
+    methods: ['POST']

--- a/public_html/tests/CsrfMiddlewareTest.php
+++ b/public_html/tests/CsrfMiddlewareTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+use app\Container\Application;
+use app\Http\Request;
+use app\Http\Response;
+use app\Middleware\Csrf;
+use app\Service\AuthService;
+use app\Service\CsrfService;
+use app\Service\SessionService;
+
+if (defined('DOC_ROOT') === false) {
+    define('DOC_ROOT', dirname(__DIR__));
+}
+
+if (defined('WEB_ROOT') === false) {
+    define('WEB_ROOT', 'https://example.test/');
+}
+
+require __DIR__ . '/../app/Container/Container.php';
+require __DIR__ . '/../app/Container/Application.php';
+require __DIR__ . '/../app/Http/Superglobal.php';
+require __DIR__ . '/../app/Http/Request.php';
+require __DIR__ . '/../app/Http/Response.php';
+require __DIR__ . '/../app/Service/SessionService.php';
+require __DIR__ . '/../app/Service/AuthSessionKeys.php';
+require __DIR__ . '/../app/Service/AuthService.php';
+require __DIR__ . '/../app/Service/CsrfService.php';
+require __DIR__ . '/../app/Middleware/Csrf.php';
+
+final class CsrfTestSession extends SessionService
+{
+    private array $store = [];
+    public int $regenerateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function get(string $key, $default = null): mixed
+    {
+        return $this->store[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->store[$key] = $value;
+    }
+
+    public function remove(string $key): void
+    {
+        unset($this->store[$key]);
+    }
+
+    public function regenerate(): void
+    {
+        $this->regenerateCount++;
+    }
+}
+
+final class CsrfTestRequest extends Request
+{
+    public function __construct(
+        private string $testMethod,
+        private array $testHeaders = [],
+        private array $testPost = [],
+    ) {
+    }
+
+    public function getMethod(): string
+    {
+        return $this->testMethod;
+    }
+
+    public function getHeader(string $key): mixed
+    {
+        return $this->testHeaders[$key] ?? null;
+    }
+
+    public function post(string $key, $default = null): mixed
+    {
+        return $this->testPost[$key] ?? $default;
+    }
+}
+
+
+final class CsrfTestTranslationService
+{
+    private array $messages = [
+        'csrf-title' => 'Page expired',
+        'csrf-message' => 'This page or form expired. Please refresh the page or return to the form, then try again. Your action was not submitted.',
+        'csrf-action' => 'Return and try again',
+    ];
+
+    public function get(string $key): string
+    {
+        return $this->messages[$key] ?? $key;
+    }
+}
+
+final class CsrfTestApplication extends Application
+{
+    private array $services = [];
+
+    public function __construct()
+    {
+    }
+
+    public function addService(string $name, object|callable|null $service): void
+    {
+        $this->services[$name] = $service;
+    }
+
+    public function get(string $name): ?object
+    {
+        $service = $this->services[$name] ?? null;
+        if (is_callable($service) === true) {
+            $service = $service();
+            $this->services[$name] = $service;
+        }
+
+        return is_object($service) === true ? $service : null;
+    }
+}
+
+function makeCsrfApplication(CsrfTestSession $session): CsrfTestApplication
+{
+    $application = new CsrfTestApplication();
+    $application->addService('sessionService', $session);
+    $application->addService('csrfService', new CsrfService($session));
+    $application->addService('translationService', new CsrfTestTranslationService());
+    return $application;
+}
+
+function assertTrue(bool $condition, string $message): void
+{
+    if ($condition === false) {
+        throw new RuntimeException($message);
+    }
+}
+
+function assertSameValue(mixed $expected, mixed $actual, string $message): void
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+function runThroughCsrf(CsrfTestApplication $application, Request $request): Response
+{
+    $middleware = new Csrf($application);
+
+    return $middleware->handle(
+        $request,
+        static fn (Request $request): Response => Response::html('passed', 204)
+    );
+}
+
+
+$session = new CsrfTestSession();
+$csrf = new CsrfService($session);
+$firstInput = $csrf->renderInput();
+$secondInput = $csrf->renderInput();
+assertSameValue($firstInput, $secondInput, 'Repeated CSRF fields in one session should use the same stored token.');
+
+$session = new CsrfTestSession();
+$application = makeCsrfApplication($session);
+$response = runThroughCsrf($application, new CsrfTestRequest('GET'));
+assertSameValue(204, $response->getStatusCode(), 'Safe requests should pass without a token.');
+assertSameValue('passed', $response->getContent(), 'Safe requests should continue to the next handler.');
+
+$session = new CsrfTestSession();
+$application = makeCsrfApplication($session);
+$response = runThroughCsrf($application, new CsrfTestRequest('POST'));
+assertSameValue(419, $response->getStatusCode(), 'State-changing requests without a token should return 419.');
+assertTrue(str_contains($response->getContent(), 'This page or form expired') === true, 'HTML CSRF failures should use the friendly translated message.');
+
+$session = new CsrfTestSession();
+$application = makeCsrfApplication($session);
+$response = runThroughCsrf($application, new CsrfTestRequest('POST', ['Accept' => 'application/json'], [CsrfService::FIELD_NAME => 'invalid-token']));
+assertSameValue(419, $response->getStatusCode(), 'Invalid tokens should return 419.');
+$payload = json_decode($response->getContent(), true);
+assertSameValue('csrf_token_invalid', $payload['error'] ?? null, 'JSON CSRF failures should include a structured error code.');
+assertSameValue('This page or form expired. Please refresh the page or return to the form, then try again. Your action was not submitted.', $payload['message'] ?? null, 'JSON CSRF failures should include a translated message.');
+
+$session = new CsrfTestSession();
+$application = makeCsrfApplication($session);
+$token = $application->get('csrfService')->getToken();
+$response = runThroughCsrf($application, new CsrfTestRequest('POST', [], [CsrfService::FIELD_NAME => $token]));
+assertSameValue(204, $response->getStatusCode(), 'Valid form tokens should pass.');
+
+$session = new CsrfTestSession();
+$application = makeCsrfApplication($session);
+$token = $application->get('csrfService')->getToken();
+$response = runThroughCsrf($application, new CsrfTestRequest('DELETE', ['X-CSRF-Token' => $token]));
+assertSameValue(204, $response->getStatusCode(), 'Valid X-CSRF-Token headers should pass.');
+
+
+$session = new CsrfTestSession();
+$application = makeCsrfApplication($session);
+$csrf = $application->get('csrfService');
+$tokenBeforeLogin = $csrf->getToken();
+$auth = new AuthService($application);
+$auth->loginUser(123);
+assertSameValue(1, $session->regenerateCount, 'Successful login should regenerate the session ID.');
+assertTrue($tokenBeforeLogin !== $csrf->getToken(), 'Successful login should rotate the CSRF token.');
+
+$tokenBeforeLogout = $csrf->getToken();
+$auth->logoutUser();
+assertSameValue(2, $session->regenerateCount, 'Logout should regenerate the session ID.');
+assertTrue($tokenBeforeLogout !== $csrf->getToken(), 'Logout should rotate the CSRF token.');
+
+
+$middleware = new Csrf(makeCsrfApplication(new CsrfTestSession()));
+$getBackUrl = new ReflectionMethod(Csrf::class, 'getBackUrl');
+$sameOriginBackUrl = $getBackUrl->invoke($middleware, new CsrfTestRequest('POST', ['Referer' => 'https://example.test/account']));
+assertSameValue('https://example.test/account', $sameOriginBackUrl, 'Same-origin CSRF back URLs should be preserved.');
+$externalBackUrl = $getBackUrl->invoke($middleware, new CsrfTestRequest('POST', ['Referer' => 'https://evil.example/phish']));
+assertSameValue(WEB_ROOT, $externalBackUrl, 'External CSRF back URLs should fall back to WEB_ROOT.');
+
+print "CSRF middleware tests passed.\n";


### PR DESCRIPTION
### Motivation
- Introduce site-wide CSRF protection to validate state-changing requests and provide friendly error handling when tokens are missing or invalid.
- Ensure CSRF tokens are rotated on session-regenerating events such as login and logout to reduce token reuse risk.

### Description
- Add `app\Service\CsrfService` implementing token generation, rotation, validation, and helpers (`FIELD_NAME`, `getToken`, `rotateToken`, `renderInput`, `isValidRequest`).
- Add `app\Middleware\Csrf` middleware that enforces CSRF checks for state-changing methods and returns JSON or an application-styled error page on failure, plus origin-safe back URL logic.
- Add `app\Twig\CsrfExtension` exposing `csrf_token` and `csrf_field` Twig helpers and wire the extension into `app\Middleware\Twig`.
- Register the CSRF service during session initialization in `app\Middleware\Session`, adjust middleware order in `app/middleware.php` to mount Twig before CSRF, and move `AuthSessionJWT` after CSRF.
- Update templates to include CSRF hidden inputs (`csrf_field()`) and convert logout links to POST forms, and add an `error/csrf.twig` view and translation strings for friendly messages (`csrf-title`, `csrf-message`, `csrf-action`).
- Rotate CSRF tokens on authentication state changes by adding `AuthService::rotateCsrfToken()` and calling it from `loginUser()` and `logoutUser()`, and call rotation where MFA setup/teardown changes session data.
- Change the `logout` route to accept `POST` and update `Logout` controller to redirect with `303`.

### Testing
- Added `public_html/tests/CsrfMiddlewareTest.php` exercising token generation/consistency, safe request passthrough, HTML and JSON failure responses, header and form token validation, token rotation on login/logout, and `getBackUrl` origin checks; this test suite passed (prints "CSRF middleware tests passed.").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a60eb01b30483249f0f7e03fdff44f3)