### PR TITLE
Harden QueryBuilder: identifier/operator validation, IN/IS NULL handling, and SQL generation tests

### DIFF
--- a/public_html/src/Data/QueryBuilder.php
+++ b/public_html/src/Data/QueryBuilder.php
@@ -4,8 +4,17 @@ declare(strict_types=1);
 
 namespace src\Data;
 
+use InvalidArgumentException;
+
 class QueryBuilder
 {
+    private const IDENTIFIER_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]*$/';
+
+    private const ALLOWED_OPERATORS = [
+        '=', '!=', '<>', '<', '<=', '>', '>=',
+        'LIKE', 'NOT LIKE', 'IS', 'IS NOT', 'IN', 'NOT IN',
+    ];
+
     protected \PDO $connection;
 
     protected string $table;
@@ -17,7 +26,7 @@ class QueryBuilder
     public function __construct(\PDO $connection, string $table)
     {
         $this->connection = $connection;
-        $this->table = $table;
+        $this->table = self::validateIdentifier($table, 'table');
     }
 
     /**
@@ -30,11 +39,31 @@ class QueryBuilder
      */
     public function where(string $column, $operator, $value = null): self
     {
-        if ($value === null) {
+        $column = self::validateIdentifier($column, 'column');
+
+        if ($value === null && !$this->isExplicitNullOperator($operator)) {
             $value = $operator;
             $operator = '=';
         }
-        $this->wheres[] = [$column, $operator, $value];
+
+        $operator = self::validateOperator((string) $operator);
+
+        if (in_array($operator, ['IN', 'NOT IN'], true)) {
+            if (!is_array($value) || $value === []) {
+                throw new InvalidArgumentException("Operator {$operator} requires a non-empty array value.");
+            }
+
+            $placeholders = implode(', ', array_fill(0, count($value), '?'));
+            $this->wheres[] = ["{$column} {$operator} ({$placeholders})", array_values($value)];
+            return $this;
+        }
+
+        if (in_array($operator, ['IS', 'IS NOT'], true) && $value === null) {
+            $this->wheres[] = ["{$column} {$operator} NULL", []];
+            return $this;
+        }
+
+        $this->wheres[] = ["{$column} {$operator} ?", [$value]];
         return $this;
     }
 
@@ -46,6 +75,10 @@ class QueryBuilder
      */
     public function limit(int $limit): self
     {
+        if ($limit < 0) {
+            throw new InvalidArgumentException('Limit must be a non-negative integer.');
+        }
+
         $this->limit = $limit;
         return $this;
     }
@@ -59,6 +92,7 @@ class QueryBuilder
      */
     public function orderBy(string $column, string $direction = 'ASC'): self
     {
+        $column = self::validateIdentifier($column, 'column');
         $direction = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
         $this->orderBys[] = [$column, $direction];
         return $this;
@@ -71,22 +105,8 @@ class QueryBuilder
      */
     public function first()
     {
-        $query = "SELECT * FROM {$this->table}";
         $bindings = [];
-
-        if ((bool) $this->wheres === true) {
-            $query .= " WHERE " . implode(' AND ', array_map(function ($where) use (&$bindings) {
-                $bindings[] = $where[2];
-                return "{$where[0]} {$where[1]} ?";
-            }, $this->wheres));
-        }
-
-        if ((bool) $this->orderBys === true) {
-            $query .= " ORDER BY " . implode(', ', array_map(function ($orderBy) {
-                return "{$orderBy[0]} {$orderBy[1]}";
-            }, $this->orderBys));
-        }
-
+        $query = $this->buildSelectQuery($bindings);
         $query .= " LIMIT 1";
 
         $stmt = $this->connection->prepare($query);
@@ -101,21 +121,8 @@ class QueryBuilder
      */
     public function get(): array
     {
-        $query = "SELECT * FROM {$this->table}";
         $bindings = [];
-
-        if ((bool) $this->wheres === true) {
-            $query .= " WHERE " . implode(' AND ', array_map(function ($where) use (&$bindings) {
-                $bindings[] = $where[2];
-                return "{$where[0]} {$where[1]} ?";
-            }, $this->wheres));
-        }
-
-        if ((bool) $this->orderBys === true) {
-            $query .= " ORDER BY " . implode(', ', array_map(function ($orderBy) {
-                return "{$orderBy[0]} {$orderBy[1]}";
-            }, $this->orderBys));
-        }
+        $query = $this->buildSelectQuery($bindings);
 
         if ($this->limit !== null) {
             $query .= " LIMIT {$this->limit}";
@@ -134,9 +141,16 @@ class QueryBuilder
      */
     public function insert(array $data): bool
     {
-        $columns = implode(', ', array_keys($data));
+        $columns = array_map(function ($column): string {
+            return self::validateIdentifier((string) $column, 'column');
+        }, array_keys($data));
+
+        if ($columns === []) {
+            throw new InvalidArgumentException('Insert data cannot be empty.');
+        }
+
         $placeholders = implode(', ', array_fill(0, count($data), '?'));
-        $query = "INSERT INTO {$this->table} ({$columns}) VALUES ({$placeholders})";
+        $query = "INSERT INTO {$this->table} (" . implode(', ', $columns) . ") VALUES ({$placeholders})";
         $stmt = $this->connection->prepare($query);
         return (bool) $stmt->execute(array_values($data));
     }
@@ -149,17 +163,16 @@ class QueryBuilder
      */
     public function update(array $data): bool
     {
-        $query = "UPDATE {$this->table} SET " . implode(', ', array_map(function ($key) {
-            return "{$key} = ?";
+        if ($data === []) {
+            throw new InvalidArgumentException('Update data cannot be empty.');
+        }
+
+        $query = "UPDATE {$this->table} SET " . implode(', ', array_map(function ($key): string {
+            return self::validateIdentifier((string) $key, 'column') . " = ?";
         }, array_keys($data)));
 
         $bindings = array_values($data);
-        if ((bool) $this->wheres === true) {
-            $query .= " WHERE " . implode(' AND ', array_map(function ($where) use (&$bindings) {
-                $bindings[] = $where[2];
-                return "{$where[0]} {$where[1]} ?";
-            }, $this->wheres));
-        }
+        $query .= $this->buildWhereClause($bindings);
 
         $stmt = $this->connection->prepare($query);
         return (bool) $stmt->execute($bindings);
@@ -174,14 +187,68 @@ class QueryBuilder
     {
         $query = "DELETE FROM {$this->table}";
         $bindings = [];
-        if ((bool) $this->wheres === true) {
-            $query .= " WHERE " . implode(' AND ', array_map(function ($where) use (&$bindings) {
-                $bindings[] = $where[2];
-                return "{$where[0]} {$where[1]} ?";
-            }, $this->wheres));
-        }
+        $query .= $this->buildWhereClause($bindings);
 
         $stmt = $this->connection->prepare($query);
         return (bool) $stmt->execute($bindings);
+    }
+
+    private static function validateIdentifier(string $identifier, string $type): string
+    {
+        if (!preg_match(self::IDENTIFIER_PATTERN, $identifier)) {
+            throw new InvalidArgumentException("Invalid {$type} identifier: {$identifier}");
+        }
+
+        return $identifier;
+    }
+
+    private static function validateOperator(string $operator): string
+    {
+        $operator = strtoupper(preg_replace('/\s+/', ' ', trim($operator)) ?? '');
+
+        if (!in_array($operator, self::ALLOWED_OPERATORS, true)) {
+            throw new InvalidArgumentException("Invalid where operator: {$operator}");
+        }
+
+        return $operator;
+    }
+
+    private function isExplicitNullOperator($operator): bool
+    {
+        if (!is_string($operator)) {
+            return false;
+        }
+
+        $operator = strtoupper(preg_replace('/\s+/', ' ', trim($operator)) ?? '');
+        return in_array($operator, ['IS', 'IS NOT'], true);
+    }
+
+    private function buildSelectQuery(array &$bindings): string
+    {
+        $query = "SELECT * FROM {$this->table}";
+        $query .= $this->buildWhereClause($bindings);
+
+        if ((bool) $this->orderBys === true) {
+            $query .= " ORDER BY " . implode(', ', array_map(function ($orderBy) {
+                return "{$orderBy[0]} {$orderBy[1]}";
+            }, $this->orderBys));
+        }
+
+        return $query;
+    }
+
+    private function buildWhereClause(array &$bindings): string
+    {
+        if ((bool) $this->wheres !== true) {
+            return '';
+        }
+
+        return " WHERE " . implode(' AND ', array_map(function ($where) use (&$bindings) {
+            foreach ($where[1] as $binding) {
+                $bindings[] = $binding;
+            }
+
+            return $where[0];
+        }, $this->wheres));
     }
 }

--- a/public_html/tests/QueryBuilderSqlGenerationTest.php
+++ b/public_html/tests/QueryBuilderSqlGenerationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/Data/QueryBuilder.php';
+
+use src\Data\QueryBuilder;
+
+final class RecordingStatement extends PDOStatement
+{
+    public array $bindings = [];
+
+    public function execute(?array $params = null): bool
+    {
+        $this->bindings = $params ?? [];
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): mixed
+    {
+        return false;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return [];
+    }
+}
+
+final class RecordingPdo extends PDO
+{
+    public string $lastQuery = '';
+    public ?RecordingStatement $lastStatement = null;
+
+    public function __construct()
+    {
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        $this->lastQuery = $query;
+        $this->lastStatement = new RecordingStatement();
+        return $this->lastStatement;
+    }
+}
+
+function assertSameValue($expected, $actual, string $message): void
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException($message . PHP_EOL . 'Expected: ' . var_export($expected, true) . PHP_EOL . 'Actual: ' . var_export($actual, true));
+    }
+}
+
+function assertThrows(callable $callback, string $message): void
+{
+    try {
+        $callback();
+    } catch (InvalidArgumentException) {
+        return;
+    }
+
+    throw new RuntimeException($message);
+}
+
+$pdo = new RecordingPdo();
+(new QueryBuilder($pdo, 'user'))->where('username', 'alice')->where('id', '>=', 5)->get();
+assertSameValue('SELECT * FROM user WHERE username = ? AND id >= ?', $pdo->lastQuery, 'where() should generate safe SQL.');
+assertSameValue(['alice', 5], $pdo->lastStatement->bindings, 'where() should bind values.');
+
+$pdo = new RecordingPdo();
+(new QueryBuilder($pdo, 'totp_email'))->where('id', 'IN', [1, 2])->where('deleted_at', 'IS', null)->get();
+assertSameValue('SELECT * FROM totp_email WHERE id IN (?, ?) AND deleted_at IS NULL', $pdo->lastQuery, 'where() should support IN and IS NULL.');
+assertSameValue([1, 2], $pdo->lastStatement->bindings, 'IN should bind each value.');
+
+$pdo = new RecordingPdo();
+(new QueryBuilder($pdo, 'totp_email'))->orderBy('created_at', 'DESC')->limit(10)->get();
+assertSameValue('SELECT * FROM totp_email ORDER BY created_at DESC LIMIT 10', $pdo->lastQuery, 'orderBy() and limit() should generate safe SQL.');
+assertSameValue([], $pdo->lastStatement->bindings, 'limit() should be constrained before interpolation, not string-bound through execute().');
+
+$pdo = new RecordingPdo();
+(new QueryBuilder($pdo, 'user'))->insert(['username' => 'alice', 'email' => 'alice@example.com']);
+assertSameValue('INSERT INTO user (username, email) VALUES (?, ?)', $pdo->lastQuery, 'insert() should generate safe SQL.');
+assertSameValue(['alice', 'alice@example.com'], $pdo->lastStatement->bindings, 'insert() should bind values.');
+
+$pdo = new RecordingPdo();
+(new QueryBuilder($pdo, 'user'))->where('id', 7)->update(['email' => 'new@example.com']);
+assertSameValue('UPDATE user SET email = ? WHERE id = ?', $pdo->lastQuery, 'update() should generate safe SQL.');
+assertSameValue(['new@example.com', 7], $pdo->lastStatement->bindings, 'update() should bind values.');
+
+$pdo = new RecordingPdo();
+(new QueryBuilder($pdo, 'user'))->where('id', 7)->delete();
+assertSameValue('DELETE FROM user WHERE id = ?', $pdo->lastQuery, 'delete() should generate safe SQL.');
+assertSameValue([7], $pdo->lastStatement->bindings, 'delete() should bind values.');
+
+assertThrows(fn() => new QueryBuilder(new RecordingPdo(), 'user; DROP TABLE user'), 'Invalid table names should be rejected.');
+assertThrows(fn() => new QueryBuilder(new RecordingPdo(), 'schema.user'), 'Schema-qualified table names should be rejected by the current simple identifier policy.');
+assertThrows(fn() => (new QueryBuilder(new RecordingPdo(), 'user'))->where('email; DROP', 'x'), 'Invalid where columns should be rejected.');
+assertThrows(fn() => (new QueryBuilder(new RecordingPdo(), 'user'))->where('user.email', 'x'), 'Qualified where columns should be rejected by the current simple identifier policy.');
+assertThrows(fn() => (new QueryBuilder(new RecordingPdo(), 'user'))->where('email', 'REGEXP', 'x'), 'Invalid where operators should be rejected.');
+assertThrows(fn() => (new QueryBuilder(new RecordingPdo(), 'user'))->orderBy('created_at DESC'), 'Invalid orderBy columns should be rejected.');
+assertThrows(fn() => (new QueryBuilder(new RecordingPdo(), 'user'))->limit(-1), 'Negative limits should be rejected.');
+
+fwrite(STDOUT, "QueryBuilder SQL generation tests passed.\n");


### PR DESCRIPTION
### Motivation
- Prevent injection and malformed SQL by validating table/column identifiers and allowed operators before building queries. 
- Properly support multi-value `IN`/`NOT IN` bindings and `IS`/`IS NOT NULL` semantics while keeping bindings safe.
- Add deterministic tests to assert generated SQL and bindings and to ensure invalid inputs raise exceptions.

### Description
- Added identifier and operator validation with `IDENTIFIER_PATTERN`, `ALLOWED_OPERATORS`, `validateIdentifier()`, and `validateOperator()` to reject unsafe table/column names and unsupported operators. 
- Reworked `where()` to normalize operators, support `IN`/`NOT IN` with dynamic placeholders and multiple bindings, support `IS`/`IS NOT NULL`, and store clause fragments with associated bindings. 
- Introduced `buildWhereClause()` and `buildSelectQuery()` to centralize SQL assembly and binding collection for `get()`, `first()`, `update()`, and `delete()`. 
- Validated `limit()` to reject negative values, validated and enforced non-empty payloads for `insert()` and `update()`, and validated column names used in `insert()` and `update()`. 
- Kept prepared statement usage and binding semantics intact while changing how clauses and bindings are accumulated for safe execution. 

### Testing
- Ran the new test script `php public_html/tests/QueryBuilderSqlGenerationTest.php` which uses a `RecordingPdo`/`RecordingStatement` harness to capture SQL and bindings. 
- All assertions in the test file passed, including tests for `where()` SQL and bindings, `IN` and `IS NULL` behavior, `orderBy()`/`limit()`, `insert()`/`update()`/`delete()`, and that invalid identifiers/operators and negative limits throw `InvalidArgumentException`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f80825aa88324a6106ffef9750575)