### PR TITLE
Fix account auth redirect status codes

### DIFF
--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -44,19 +44,19 @@ class Account extends Controller
         $this->application->get('translationService')->setFile('account');
         $auth = $this->auth();
 
-        $redirect = $this->enforceAuthentication($auth);
+        $redirect = $this->enforceAuthentication($request, $auth);
         if ($redirect instanceof Response) {
             return $redirect;
         }
 
         $userId = $auth->getAuthenticatedUserId();
         if ($userId === null) {
-            return Response::redirect(APP_BASE . '/login', 301);
+            return $this->redirectToLogin($request);
         }
 
         $user = $this->userService->getUserById($userId);
         if ($user === null) {
-            return Response::redirect(APP_BASE . '/login', 301);
+            return $this->redirectToLogin($request);
         }
 
         $this->accountMessages = $this->consumeFlash('account');
@@ -141,13 +141,20 @@ class Account extends Controller
         );
     }
 
-    private function enforceAuthentication(AuthService $auth): ?Response
+    private function enforceAuthentication(Request $request, AuthService $auth): ?Response
     {
         if ($auth->getAuthenticatedUserId() === null) {
-            return Response::redirect(APP_BASE . '/login', 301);
+            return $this->redirectToLogin($request);
         }
 
         return null;
+    }
+
+    private function redirectToLogin(Request $request): Response
+    {
+        $statusCode = strtoupper($request->getMethod()) === 'POST' ? 303 : 302;
+
+        return Response::redirect(APP_BASE . '/login', $statusCode);
     }
 
     private function handleUsernameChange(Request $request, User $user): User

--- a/public_html/tests/AccountRedirectStatusTest.php
+++ b/public_html/tests/AccountRedirectStatusTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use app\Container\Application;
+use app\Http\Request;
+use app\Http\Response;
+use src\Controller\Account;
+
+if (defined('DOC_ROOT') === false) {
+    define('DOC_ROOT', dirname(__DIR__));
+}
+
+if (defined('APP_BASE') === false) {
+    define('APP_BASE', '/game');
+}
+
+spl_autoload_register(static function (string $class): void {
+    $prefixes = [
+        'app\\' => DOC_ROOT . '/app/',
+        'src\\' => DOC_ROOT . '/src/',
+    ];
+
+    foreach ($prefixes as $prefix => $baseDir) {
+        if (str_starts_with($class, $prefix) === false) {
+            continue;
+        }
+
+        $relativeClass = substr($class, strlen($prefix));
+        $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+        if (is_file($file) === true) {
+            require $file;
+        }
+    }
+});
+
+
+final class AccountRedirectTestSession
+{
+    public function set(string $key, mixed $value): void
+    {
+    }
+}
+
+final class AccountRedirectTestApplication extends Application
+{
+    public function __construct()
+    {
+    }
+
+    public function get(string $name): ?object
+    {
+        if ($name === 'sessionService') {
+            return new AccountRedirectTestSession();
+        }
+
+        return null;
+    }
+}
+
+final class AccountRedirectTestRequest extends Request
+{
+    public function __construct(private string $testMethod)
+    {
+    }
+
+    public function getMethod(): string
+    {
+        return $this->testMethod;
+    }
+}
+
+function assertSameValue(mixed $expected, mixed $actual, string $message): void
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+function assertHeaderContains(Response $response, string $expectedHeader, string $message): void
+{
+    if (in_array($expectedHeader, $response->getHeaders(), true) === false) {
+        throw new RuntimeException($message . ' Headers: ' . var_export($response->getHeaders(), true));
+    }
+}
+
+$account = (new ReflectionClass(Account::class))->newInstanceWithoutConstructor();
+$applicationProperty = new ReflectionProperty(Account::class, 'application');
+$applicationProperty->setAccessible(true);
+$applicationProperty->setValue($account, new AccountRedirectTestApplication());
+$redirectToLogin = new ReflectionMethod(Account::class, 'redirectToLogin');
+$redirectToLogin->setAccessible(true);
+
+$getResponse = $redirectToLogin->invoke($account, new AccountRedirectTestRequest('GET'));
+assertSameValue(302, $getResponse->getStatusCode(), 'Unauthenticated GET navigation to account should use a temporary 302 redirect.');
+assertHeaderContains($getResponse, 'Location: /game/login', 'GET account redirects should point to login.');
+
+$postResponse = $redirectToLogin->invoke($account, new AccountRedirectTestRequest('POST'));
+assertSameValue(303, $postResponse->getStatusCode(), 'Unauthenticated POST actions to account should use 303 for Post/Redirect/Get.');
+assertHeaderContains($postResponse, 'Location: /game/login', 'POST account redirects should point to login.');
+
+$redirectScanRoots = [DOC_ROOT . '/src', DOC_ROOT . '/app'];
+foreach ($redirectScanRoots as $root) {
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+    foreach ($iterator as $file) {
+        if ($file->isFile() === false || $file->getExtension() !== 'php') {
+            continue;
+        }
+
+        $contents = (string) file_get_contents($file->getPathname());
+        if (preg_match('/Response::redirect\([^;]*,\s*301\s*\)/s', $contents) === 1) {
+            throw new RuntimeException('Non-permanent redirects under public_html/src and public_html/app must not use 301: ' . $file->getPathname());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace permanent `301` redirects used for unauthenticated access with temporary redirects to avoid caching and allow correct method semantics.
- Preserve the Post/Redirect/Get pattern by returning `303` after unauthenticated `POST` actions so clients follow with a `GET`. 
- Ensure ordinary unauthenticated `GET` navigation uses a temporary `302` to indicate a non-permanent redirect.

### Description
- Updated `public_html/src/Controller/Account.php` to route all login redirects through a new `redirectToLogin(Request $request)` helper which returns `303` for `POST` and `302` otherwise. 
- Changed `enforceAuthentication()` to accept the `Request` object and to use `redirectToLogin()` instead of returning `Response::redirect(..., 301)`. 
- Replaced the direct `Response::redirect(..., 301)` usages in the Account controller with calls to `redirectToLogin()`. 
- Added `public_html/tests/AccountRedirectStatusTest.php` which asserts `302` for unauthenticated `GET`, `303` for unauthenticated `POST`, and scans `public_html/src` and `public_html/app` for any remaining `Response::redirect(..., 301)` occurrences to prevent regressions.

### Testing
- Ran `php -l public_html/src/Controller/Account.php` and the file lint check passed. 
- Executed the new redirect test via `php public_html/tests/AccountRedirectStatusTest.php`, which exercises the helper and the code-scan and completed successfully after adjustments. 
- Verified existing tests `php public_html/tests/CsrfMiddlewareTest.php` and `php public_html/tests/QueryBuilderSqlGenerationTest.php` and both passed. 
- Searched for `Response::redirect(..., 301)` under `public_html/src` and `public_html/app` and no non-permanent redirects remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a623d1da41c8324b889f23edaa3ce36)