### PR TITLE
Move AuthEntryService wiring to Application container

### DIFF
--- a/public_html/app/Container/Application.php
+++ b/public_html/app/Container/Application.php
@@ -5,6 +5,14 @@ declare(strict_types=1);
 namespace app\Container;
 
 use app\Http\Router;
+use app\Service\JWTService;
+use app\Service\SessionService;
+use src\Business\AuthEntryService;
+use src\Business\EmailService;
+use src\Business\MFATOTPService;
+use src\Business\TOTPEmailService;
+use src\Business\TOTPService;
+use src\Business\UserService;
 
 class Application extends Container
 {
@@ -27,6 +35,36 @@ class Application extends Container
         $this->addService('dbh', fn(): \src\Data\Connection => new \src\Data\Connection());
         $this->addService('router', $this->router = new Router());
         $this->addService('translationService', new \app\Service\TranslationService());
+        $this->addService('userService', fn(): UserService => new UserService($this));
+        $this->addService('mfaTotpService', fn(): MFATOTPService => new MFATOTPService($this));
+        $this->addService('totpEmailService', fn(): TOTPEmailService => new TOTPEmailService($this));
+        $this->addService('totpService', fn(): TOTPService => new TOTPService());
+        $this->addService('emailService', fn(): EmailService => new EmailService());
+        $this->addService('jwtService', fn(): JWTService => new JWTService($this));
+        $this->addService('authEntryService', fn(): AuthEntryService => new AuthEntryService(
+            $this->getRegisteredService('userService', UserService::class),
+            $this->getRegisteredService('mfaTotpService', MFATOTPService::class),
+            $this->getRegisteredService('totpEmailService', TOTPEmailService::class),
+            $this->getRegisteredService('totpService', TOTPService::class),
+            $this->getRegisteredService('emailService', EmailService::class),
+            $this->getRegisteredService('jwtService', JWTService::class),
+            $this->getRegisteredService('sessionService', SessionService::class)
+        ));
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     * @return T
+     */
+    private function getRegisteredService(string $name, string $className): object
+    {
+        $service = $this->get($name);
+        if (($service instanceof $className) === false) {
+            throw new \RuntimeException($name . ' service is not available.');
+        }
+
+        return $service;
     }
 
     private function configure(string $dir): void

--- a/public_html/src/Controller/AuthEntryController.php
+++ b/public_html/src/Controller/AuthEntryController.php
@@ -7,14 +7,7 @@ namespace src\Controller;
 use app\Http\Request;
 use app\Http\Response;
 use app\Service\AuthService;
-use app\Service\JWTService;
-use app\Service\SessionService;
 use src\Business\AuthEntryService;
-use src\Business\EmailService;
-use src\Business\MFATOTPService;
-use src\Business\TOTPEmailService;
-use src\Business\TOTPService;
-use src\Business\UserService;
 
 class AuthEntryController extends Controller
 {
@@ -174,20 +167,12 @@ class AuthEntryController extends Controller
 
     protected function authEntryService(): AuthEntryService
     {
-        $sessionService = $this->application->get('sessionService');
-        if (($sessionService instanceof SessionService) === false) {
-            throw new \RuntimeException('Session service is not available.');
+        $authEntryService = $this->application->get('authEntryService');
+        if (($authEntryService instanceof AuthEntryService) === false) {
+            throw new \RuntimeException('Auth entry service is not available.');
         }
 
-        return new AuthEntryService(
-            new UserService($this->application),
-            new MFATOTPService($this->application),
-            new TOTPEmailService($this->application),
-            new TOTPService(),
-            new EmailService(),
-            new JWTService($this->application),
-            $sessionService
-        );
+        return $authEntryService;
     }
 
     private function translateForMode(string $mode, string $key): string


### PR DESCRIPTION
### Motivation
- Centralize construction of auth-entry dependencies so controllers no longer instantiate service graphs directly.  
- Preserve the existing `SessionService` type guard behavior while avoiding duplicated wiring across controllers.  
- Prepare for easier testing and future refactors by registering shared services in the application container.

### Description
- Registered `userService`, `mfaTotpService`, `totpEmailService`, `totpService`, `emailService`, `jwtService` and `authEntryService` in `public_html/app/Container/Application.php`.  
- Built `authEntryService` from the registered services using a new typed helper `getRegisteredService(string $name, string $className): object` to enforce runtime type checks.  
- Replaced inline construction in `public_html/src/Controller/AuthEntryController.php` by returning `$this->application->get('authEntryService')` with an `instanceof` guard.  
- Removed now-unnecessary direct service `use` imports in the controller and kept the `SessionService` guard semantics via the container accessor.

### Testing
- Ran `php -l public_html/app/Container/Application.php` and it succeeded.  
- Ran `php -l public_html/src/Controller/AuthEntryController.php` and it succeeded.  
- Ran `git diff --check` with no reported issues.  
- Attempted `cd public_html && composer test` but the project does not define a Composer `test` script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a626b9be564832489960bb58c303f95)