### PR TITLE
Refactor MFA/TOTP services to accept injected dependencies

### DIFF
--- a/public_html/app/Container/Application.php
+++ b/public_html/app/Container/Application.php
@@ -13,6 +13,9 @@ use src\Business\MFATOTPService;
 use src\Business\TOTPEmailService;
 use src\Business\TOTPService;
 use src\Business\UserService;
+use src\Data\Connection;
+use src\Data\Repository\TOTPEmailRepository;
+use src\Data\Repository\UserMFATOTPRepository;
 
 class Application extends Container
 {
@@ -32,13 +35,26 @@ class Application extends Container
 
     private function registerServices(): void
     {
-        $this->addService('dbh', fn(): \src\Data\Connection => new \src\Data\Connection());
+        $this->addService('dbh', fn(): Connection => new Connection());
         $this->addService('router', $this->router = new Router());
         $this->addService('translationService', new \app\Service\TranslationService());
         $this->addService('userService', fn(): UserService => new UserService($this));
-        $this->addService('mfaTotpService', fn(): MFATOTPService => new MFATOTPService($this));
-        $this->addService('totpEmailService', fn(): TOTPEmailService => new TOTPEmailService($this));
         $this->addService('totpService', fn(): TOTPService => new TOTPService());
+        $this->addService('userMfaTotpRepository', fn(): UserMFATOTPRepository => new UserMFATOTPRepository(
+            $this->getRegisteredService('dbh', Connection::class)
+        ));
+        $this->addService('totpEmailRepository', fn(): TOTPEmailRepository => new TOTPEmailRepository(
+            $this->getRegisteredService('dbh', Connection::class)
+        ));
+        $this->addService('mfaTotpService', fn(): MFATOTPService => new MFATOTPService(
+            $this->getRegisteredService('totpService', TOTPService::class),
+            $this->getRegisteredService('userMfaTotpRepository', UserMFATOTPRepository::class)
+        ));
+        $this->addService('totpEmailService', fn(): TOTPEmailService => new TOTPEmailService(
+            $this->getRegisteredService('totpService', TOTPService::class),
+            $this->getRegisteredService('totpEmailRepository', TOTPEmailRepository::class),
+            $this->getRegisteredService('sessionService', SessionService::class)
+        ));
         $this->addService('emailService', fn(): EmailService => new EmailService());
         $this->addService('jwtService', fn(): JWTService => new JWTService($this));
         $this->addService('authEntryService', fn(): AuthEntryService => new AuthEntryService(

--- a/public_html/src/Business/MFATOTPService.php
+++ b/public_html/src/Business/MFATOTPService.php
@@ -12,10 +12,10 @@ class MFATOTPService
 
     private UserMFATOTPRepository $repository;
 
-    public function __construct(\app\Container\Application $application)
+    public function __construct(TOTPService $totpService, UserMFATOTPRepository $repository)
     {
-        $this->totpService = new TOTPService();
-        $this->repository = new UserMFATOTPRepository($application->get('dbh'));
+        $this->totpService = $totpService;
+        $this->repository = $repository;
     }
 
     public function hasEnabledMfa(int $userId): bool

--- a/public_html/src/Business/TOTPEmailService.php
+++ b/public_html/src/Business/TOTPEmailService.php
@@ -17,11 +17,14 @@ class TOTPEmailService
 
     protected SessionService $sessionService;
 
-    public function __construct(\app\Container\Application $application)
-    {
-        $this->totp = new TOTPService();
-        $this->totpEmailRepository = new TOTPEmailRepository($application->get('dbh'));
-        $this->sessionService = $application->get('sessionService');
+    public function __construct(
+        TOTPService $totp,
+        TOTPEmailRepository $totpEmailRepository,
+        SessionService $sessionService
+    ) {
+        $this->totp = $totp;
+        $this->totpEmailRepository = $totpEmailRepository;
+        $this->sessionService = $sessionService;
     }
 
     /**

--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -36,7 +36,12 @@ class Account extends Controller
         parent::__construct($application);
         $this->accountService = new AccountService($application);
         $this->userService = new UserService($application);
-        $this->mfaService = new MFATOTPService($application);
+        $mfaService = $application->get('mfaTotpService');
+        if (($mfaService instanceof MFATOTPService) === false) {
+            throw new \RuntimeException('mfaTotpService service is not available.');
+        }
+
+        $this->mfaService = $mfaService;
     }
 
     public function __invoke(Request $request): Response
@@ -244,6 +249,16 @@ class Account extends Controller
         $this->accountMessages['success'][] = __('account.email-change-requested');
     }
 
+    private function getTotpEmailService(): TOTPEmailService
+    {
+        $totpEmailService = $this->application->get('totpEmailService');
+        if (($totpEmailService instanceof TOTPEmailService) === false) {
+            throw new \RuntimeException('totpEmailService service is not available.');
+        }
+
+        return $totpEmailService;
+    }
+
     private function handleMfa(Request $request, User $user, AuthService $auth): void
     {
         $userId = $user->getId();
@@ -261,7 +276,7 @@ class Account extends Controller
                 $auth->setPendingMfaSecret($this->mfaService->generateSecret());
             }
 
-            $totpEmailService = new TOTPEmailService($this->application);
+            $totpEmailService = $this->getTotpEmailService();
             $emailCode = $totpEmailService->generateEmailTOTPForSession($userId, $auth->getMfaSetupEmailSessionKey());
 
             $emailService = new EmailService();
@@ -320,7 +335,7 @@ class Account extends Controller
                 return;
             }
 
-            $totpEmailService = new TOTPEmailService($this->application);
+            $totpEmailService = $this->getTotpEmailService();
             if ($totpEmailService->verifyEmailTOTPForSession($userId, $emailCode, $auth->getMfaSetupEmailSessionKey()) === false) {
                 $this->accountMessages['errors'][] = __('account.mfa-email-code-invalid');
                 return;


### PR DESCRIPTION
### Motivation

- Decouple MFA/TOTP business services from the `Application` container so dependencies are passed explicitly and are easier to test and reason about.

### Description

- Change `MFATOTPService` constructor to accept `TOTPService $totpService` and `UserMFATOTPRepository $repository` and remove internal `new`/`Application`-based construction.
- Change `TOTPEmailService` constructor to accept `TOTPService $totp`, `TOTPEmailRepository $totpEmailRepository`, and `SessionService $sessionService` and remove internal `new`/`Application`-based construction.
- Register `userMfaTotpRepository` and `totpEmailRepository` in `Application::registerServices()` and construct `mfaTotpService` and `totpEmailService` from the registered `totpService`, repositories, and `sessionService` using the existing `getRegisteredService()` runtime guard.
- Update `Account` controller to obtain `mfaTotpService` and `totpEmailService` from the application container with runtime type checks and add a `getTotpEmailService()` helper to centralize retrieval.

### Testing

- Ran `php -l public_html/src/Business/MFATOTPService.php` and it reported no syntax errors.
- Ran `php -l public_html/src/Business/TOTPEmailService.php` and it reported no syntax errors.
- Ran `php -l public_html/app/Container/Application.php` and `php -l public_html/src/Controller/Account.php` and both reported no syntax errors.
- Ran `git diff --check` (whitespace/merge checks) and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6272c688b483248f9bca80e6d76c1f)