### PR TITLE
Fix MFA login routing for username identifiers

### DIFF
--- a/public_html/src/Business/AuthEntryService.php
+++ b/public_html/src/Business/AuthEntryService.php
@@ -39,14 +39,18 @@ class AuthEntryService
 
     public function beginLogin(AuthService $auth, string $email): array
     {
-        $email = trim($email);
-        $user = $this->userService->getUserByEmail($email);
+        $identifier = trim($email);
+        $user = $this->userService->getUserByEmail($identifier);
+        if ($user === null) {
+            $user = $this->userService->getUserByUsername($identifier);
+        }
 
-        $auth->setPendingLoginEmail($email);
         $auth->setPendingLoginTotp(null);
         $auth->setLoginMfaRequired(false);
 
         if ($user !== null) {
+            $email = $user->getEmail();
+            $auth->setPendingLoginEmail($email);
             $userId = (int) $user->getId();
             $auth->setPendingUserId($userId);
             $this->sessionService->remove(self::PENDING_CREATE_BY_EMAIL);
@@ -59,9 +63,16 @@ class AuthEntryService
             return $this->sendPersistedEmailOtp($userId, $email);
         }
 
+        if ($identifier === '' || filter_var($identifier, FILTER_VALIDATE_EMAIL) === false) {
+            $auth->setPendingLoginEmail(null);
+            $auth->setPendingUserId(null);
+            return ['status' => self::STATUS_VALIDATION_ERROR, 'error' => 'provide-valid-email'];
+        }
+
+        $auth->setPendingLoginEmail($identifier);
         $auth->setPendingUserId(null);
         $this->sessionService->set(self::PENDING_CREATE_BY_EMAIL, true);
-        return $this->sendEmailOnlyOtp($email);
+        return $this->sendEmailOnlyOtp($identifier);
     }
 
     public function beginRegistration(AuthService $auth, string $username, string $email): array

--- a/public_html/tests/AuthEntryServiceTest.php
+++ b/public_html/tests/AuthEntryServiceTest.php
@@ -118,4 +118,23 @@ $svc = makeService($app->session, $users, $mfa);
 $result = $svc->beginLogin(new AuthService($app), 'known@example.test');
 assertSameValue(AuthEntryService::STATUS_APP_MFA_REQUIRED, $result['status'], 'Existing app-MFA users should be routed to app verification.');
 
+$app = new AuthEntryServiceTestApplication();
+$users = new FakeUserService();
+$users->byUsername['mfa-user'] = makeUser(8, 'mfa-user', 'mfa-user@example.test');
+$mfa = new FakeMfaService();
+$mfa->enabled = true;
+$auth = new AuthService($app);
+$svc = makeService($app->session, $users, $mfa);
+$result = $svc->beginLogin($auth, 'mfa-user');
+assertSameValue(AuthEntryService::STATUS_APP_MFA_REQUIRED, $result['status'], 'Existing app-MFA users should be found by username and routed to app verification.');
+assertSameValue('mfa-user@example.test', $auth->getPendingLoginEmail(), 'Username login should store the account email for the pending MFA session.');
+
+$app = new AuthEntryServiceTestApplication();
+$users = new FakeUserService();
+$email = new FakeEmailService();
+$svc = makeService($app->session, $users, email: $email);
+$result = $svc->beginLogin(new AuthService($app), 'not-an-email');
+assertSameValue(AuthEntryService::STATUS_VALIDATION_ERROR, $result['status'], 'Unknown non-email login identifiers should be rejected before email delivery.');
+assertSameValue([], $email->sent, 'Unknown non-email login identifiers should not try to send an OTP email.');
+
 fwrite(STDOUT, "AuthEntryService tests passed.\n");


### PR DESCRIPTION
### Motivation
- Users logging in with a username that corresponds to an existing account were being treated as unknown emails and sent an email OTP instead of being routed to the app-MFA step, causing confusing behaviour and failed email flows.

### Description
- Resolve the login identifier first by email and then by username in `AuthEntryService::beginLogin` and use the account's canonical email for pending auth state so MFA continues against the correct account.
- Reject unknown non-email identifiers early with a validation error to avoid attempting OTP delivery to invalid inputs.
- Preserve existing flow for email-only unknown logins by setting the session flag `PENDING_CREATE_BY_EMAIL` and sending an email-only OTP when the identifier is a valid email.
- Added regression tests in `public_html/tests/AuthEntryServiceTest.php` that cover username-based MFA routing and rejection of non-email identifiers.

### Testing
- Ran `php public_html/tests/AuthEntryServiceTest.php` and it passed.
- Ran `php public_html/tests/AuthEntryControllerTest.php` and it passed.
- Ran `php -l public_html/src/Business/AuthEntryService.php` and `php -l public_html/tests/AuthEntryServiceTest.php` for syntax checks and they reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a628ae0cecc8324a6f1f89f1cc2287e)