### PR TITLE
Add PHP quality workflow and composer test/check scripts

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,24 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  php:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          coverage: none
+
+      - run: composer install --no-interaction --prefer-dist
+        working-directory: public_html
+
+      - run: composer check
+        working-directory: public_html

--- a/public_html/composer.json
+++ b/public_html/composer.json
@@ -29,5 +29,17 @@
             "app\\": "app/",
             "src\\": "src/"
         }
+    },
+    "scripts": {
+        "test": [
+            "php tests/AccountRedirectStatusTest.php",
+            "php tests/AuthEntryControllerTest.php",
+            "php tests/AuthEntryServiceTest.php",
+            "php tests/CsrfMiddlewareTest.php",
+            "php tests/QueryBuilderSqlGenerationTest.php"
+        ],
+        "check": [
+            "@test"
+        ]
     }
 }


### PR DESCRIPTION
### Motivation
- Add CI to run PHP quality checks and tests on pull requests and pushes to `main`.
- Provide a standardized `composer` entry point to run the project's PHP test files with a single `check` command.

### Description
- Add `.github/workflows/quality.yml` that runs on `pull_request` and `push` to `main`, sets up PHP 8.2, runs `composer install` in `public_html`, and executes `composer check`.
- Update `public_html/composer.json` to add a `test` script that runs five PHP test files with `php` and a `check` script that invokes `@test`.
- Keep existing dependency and autoload configurations unchanged.

### Testing
- No CI run was executed as part of this change, but the workflow will run automatically on PRs and pushes to `main`.
- The `composer` test commands added are `php tests/AccountRedirectStatusTest.php`, `php tests/AuthEntryControllerTest.php`, `php tests/AuthEntryServiceTest.php`, `php tests/CsrfMiddlewareTest.php`, and `php tests/QueryBuilderSqlGenerationTest.php`, and they are executed via `composer check` when the workflow runs; their pass/fail results are not available in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a631969dbe083248e0d14e17e6c6cee)