### PR TITLE
Persist register form values on error and escape input attributes

### DIFF
--- a/public_html/src/Controller/AuthEntryController.php
+++ b/public_html/src/Controller/AuthEntryController.php
@@ -13,6 +13,7 @@ class AuthEntryController extends Controller
 {
     private const MODE_LOGIN = 'login';
     private const MODE_REGISTER = 'register';
+    private const REGISTER_FORM_VALUES = 'register.form_values';
 
     private ?string $authorizationHeader = null;
 
@@ -42,7 +43,7 @@ class AuthEntryController extends Controller
         $response = Response::html(
             $this->twig->render(
                 $mode . '.twig',
-                array_merge($this->twigVariables, $this->buildTwigVariables($auth))
+                array_merge($this->twigVariables, $this->buildTwigVariables($auth, $mode))
             )
         );
 
@@ -90,14 +91,26 @@ class AuthEntryController extends Controller
             return null;
         }
 
-        return $this->mapFirstStepResult(
-            'register',
-            $this->authEntryService()->beginRegistration(
-                $auth,
-                (string) $request->post('username'),
-                (string) $request->post('email')
-            )
+        $username = (string) $request->post('username');
+        $email = (string) $request->post('email');
+
+        $result = $this->authEntryService()->beginRegistration(
+            $auth,
+            $username,
+            $email
         );
+
+        if (in_array(
+            $result['status'] ?? null,
+            [AuthEntryService::STATUS_VALIDATION_ERROR, AuthEntryService::STATUS_SEND_ERROR],
+            true
+        ) === true) {
+            $this->rememberRegisterFormValues($username, $email);
+        } else {
+            $this->forgetRegisterFormValues();
+        }
+
+        return $this->mapFirstStepResult('register', $result);
     }
 
     private function verify(Request $request, AuthService $auth, string $mode): ?Response
@@ -165,6 +178,41 @@ class AuthEntryController extends Controller
         };
     }
 
+
+    private function rememberRegisterFormValues(string $username, string $email): void
+    {
+        $this->application->get('sessionService')->set(
+            self::REGISTER_FORM_VALUES,
+            json_encode(['username' => $username, 'email' => $email], JSON_THROW_ON_ERROR)
+        );
+    }
+
+    private function consumeRegisterFormValues(): array
+    {
+        $session = $this->application->get('sessionService');
+        $storedValues = $session->get(self::REGISTER_FORM_VALUES, '');
+        $this->forgetRegisterFormValues();
+
+        if (is_string($storedValues) === false || $storedValues === '') {
+            return [];
+        }
+
+        $values = json_decode($storedValues, true);
+        if (is_array($values) === false) {
+            return [];
+        }
+
+        return [
+            'username' => is_string($values['username'] ?? null) ? $values['username'] : '',
+            'email' => is_string($values['email'] ?? null) ? $values['email'] : null,
+        ];
+    }
+
+    private function forgetRegisterFormValues(): void
+    {
+        $this->application->get('sessionService')->remove(self::REGISTER_FORM_VALUES);
+    }
+
     protected function authEntryService(): AuthEntryService
     {
         $authEntryService = $this->application->get('authEntryService');
@@ -184,13 +232,17 @@ class AuthEntryController extends Controller
         return __($key);
     }
 
-    private function buildTwigVariables(AuthService $auth): array
+    private function buildTwigVariables(AuthService $auth, string $mode): array
     {
         $loginTotp = $auth->getPendingLoginTotp();
         $pendingEmail = $auth->getPendingLoginEmail();
+        $registerValues = ($mode === self::MODE_REGISTER && $pendingEmail === null) ?
+            $this->consumeRegisterFormValues() :
+            [];
 
         return [
-            'email' => $pendingEmail,
+            'email' => $pendingEmail ?? ($registerValues['email'] ?? null),
+            'registerUsername' => $registerValues['username'] ?? '',
             'awaitingOtp' => $pendingEmail !== null,
             'uUID' => $auth->getPendingUserId(),
             'totp' => is_string($loginTotp) === true ? str_split($loginTotp) : [],

--- a/public_html/src/View/macro/forms.twig
+++ b/public_html/src/View/macro/forms.twig
@@ -1,7 +1,7 @@
 {% macro textInput(name, value, type, label, invalidTxt) %}
     <div>
         <label for="{{ name }}" class="block">{{ label }}</label>
-        <input type="{{ type }}" name="{{ name }}" id="{{ name }}" placeholder="{{ label }}" value="{{ value }}" class="peer auth-input" autofocus autocomplete="off" required />
+        <input type="{{ type }}" name="{{ name }}" id="{{ name }}" placeholder="{{ label }}" value="{{ value|e('html_attr') }}" class="peer auth-input" autofocus autocomplete="off" required />
 
         <p class="mt-2 invisible peer-placeholder-shown:!invisible peer-invalid:visible text-pink-600 text-sm">
             {{ invalidTxt }}

--- a/public_html/src/View/partial/auth-entry.twig
+++ b/public_html/src/View/partial/auth-entry.twig
@@ -43,7 +43,7 @@
                     {{ forms.otpInput(name, value, type, label, value) }}
                 {% else %}
                     {% if authEntry.mode == 'register' %}
-                        {% set name, value, type = 'username', '', 'text' %}
+                        {% set name, value, type = 'username', registerUsername|default(''), 'text' %}
                         {{ forms.textInput(name, value, type, authEntry.usernameLabel, authEntry.usernameInvalidText) }}
                     {% endif %}
                     {% set name, value, type, submitName = 'email', email, 'email', authEntry.firstStepSubmitName %}

--- a/public_html/tests/AuthEntryControllerTest.php
+++ b/public_html/tests/AuthEntryControllerTest.php
@@ -18,7 +18,10 @@ namespace Twig {
                 }
                 $html .= '<input name="totp[]" />';
             } else {
-                $html .= '<input name="email" />';
+                if ($name === 'register.twig') {
+                    $html .= '<input name="username" value="' . htmlspecialchars((string) ($vars['registerUsername'] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '" />';
+                }
+                $html .= '<input name="email" value="' . htmlspecialchars((string) ($vars['email'] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '" />';
             }
             return $html . '</main>';
         }
@@ -177,6 +180,41 @@ assertContainsValue('otp-email-sent', $flashes['login']['success'] ?? [], 'Unkno
 [$response, $flashes, $calls] = runController('register', ['submit_register' => '1', 'username' => 'alice', 'email' => 'dupe@example.test'], ['status' => AuthEntryService::STATUS_VALIDATION_ERROR, 'error' => 'duplicate-email']);
 assertSameValue([['beginRegistration', 'alice', 'dupe@example.test']], $calls, 'Register should delegate duplicate checks to the service.');
 assertContainsValue('email-address-already-in-use', $flashes['register']['errors'] ?? [], 'Duplicate registration should map to the duplicate-email flash.');
+
+$app = new AuthEntryTestApplication();
+$service = new FakeAuthEntryService();
+$service->queue[] = ['status' => AuthEntryService::STATUS_VALIDATION_ERROR, 'error' => 'duplicate-email'];
+$response = (new TestAuthEntryController($app, $service))->handle(new AuthEntryTestRequest(['submit_register' => '1', 'username' => 'alice', 'email' => 'dupe@example.test']), 'register');
+assertSameValue('{"username":"alice","email":"dupe@example.test"}', $app->session->values['register.form_values'] ?? null, 'Failed registration should temporarily remember submitted values.');
+$response = (new TestAuthEntryController($app, new FakeAuthEntryService()))->handle(new AuthEntryTestRequest([]), 'login');
+assertSameValue('{"username":"alice","email":"dupe@example.test"}', $app->session->values['register.form_values'] ?? null, 'Visiting login should not consume remembered registration values.');
+$response = (new TestAuthEntryController($app, new FakeAuthEntryService()))->handle(new AuthEntryTestRequest([]), 'register');
+assertSameValue('alice', \Twig\Environment::$lastVars['registerUsername'] ?? null, 'Register form should expose remembered username once.');
+assertSameValue('dupe@example.test', \Twig\Environment::$lastVars['email'] ?? null, 'Register form should expose remembered email once.');
+assertResponseContains($response, 'name="username" value="alice"', 'Register form should pre-fill remembered username.');
+assertResponseContains($response, 'name="email" value="dupe@example.test"', 'Register form should pre-fill remembered email.');
+assertSameValue(false, array_key_exists('register.form_values', $app->session->values), 'Remembered registration values should be discarded after reading.');
+$response = (new TestAuthEntryController($app, new FakeAuthEntryService()))->handle(new AuthEntryTestRequest([]), 'register');
+assertSameValue('', \Twig\Environment::$lastVars['registerUsername'] ?? null, 'Register form should not expose remembered username twice.');
+assertSameValue(null, \Twig\Environment::$lastVars['email'] ?? null, 'Register form should not expose remembered email twice.');
+
+$app = new AuthEntryTestApplication();
+$service = new FakeAuthEntryService();
+$service->queue[] = ['status' => AuthEntryService::STATUS_SEND_ERROR];
+(new TestAuthEntryController($app, $service))->handle(new AuthEntryTestRequest(['submit_register' => '1', 'username' => 'send-failed', 'email' => 'failed@example.test']), 'register');
+assertSameValue('{"username":"send-failed","email":"failed@example.test"}', $app->session->values['register.form_values'] ?? null, 'Registration send errors should temporarily remember submitted values.');
+$response = (new TestAuthEntryController($app, new FakeAuthEntryService()))->handle(new AuthEntryTestRequest([]), 'register');
+assertResponseContains($response, 'name="username" value="send-failed"', 'Register form should pre-fill the username after a send error.');
+assertResponseContains($response, 'name="email" value="failed@example.test"', 'Register form should pre-fill the email after a send error.');
+assertSameValue(false, array_key_exists('register.form_values', $app->session->values), 'Send-error registration values should be discarded after reading.');
+
+$app = new AuthEntryTestApplication();
+$service = new FakeAuthEntryService();
+$service->queue[] = ['status' => AuthEntryService::STATUS_VALIDATION_ERROR, 'error' => 'invalid-username'];
+(new TestAuthEntryController($app, $service))->handle(new AuthEntryTestRequest(['submit_register' => '1', 'username' => 'alice" autofocus onfocus="alert(1)', 'email' => 'safe@example.test']), 'register');
+$response = (new TestAuthEntryController($app, new FakeAuthEntryService()))->handle(new AuthEntryTestRequest([]), 'register');
+assertResponseContains($response, 'value="alice&quot; autofocus onfocus=&quot;alert(1)"', 'Remembered registration values should be escaped in HTML attributes.');
+assertResponseNotContains($response, 'value="alice" autofocus', 'Remembered registration values should not break out of the value attribute.');
 
 [$response, $flashes, $calls] = runController('register', ['submit_register' => '1', 'username' => 'alice', 'email' => 'new@example.test'], ['status' => AuthEntryService::STATUS_EMAIL_OTP_SENT]);
 assertContainsValue('login.otp-email-sent', $flashes['register']['success'] ?? [], 'Registration should use email OTP before creating the user.');


### PR DESCRIPTION
### Motivation
- Improve user experience by preserving entered registration `username` and `email` when registration fails due to validation or send errors.
- Prevent attribute-based XSS by ensuring form input `value` attributes are properly escaped for HTML attributes.

### Description
- Add `REGISTER_FORM_VALUES` constant and session helpers `rememberRegisterFormValues`, `consumeRegisterFormValues`, and `forgetRegisterFormValues` to store and consume registration form values in session.
- Update `register()` to remember submitted `username`/`email` when `beginRegistration` returns `STATUS_VALIDATION_ERROR` or `STATUS_SEND_ERROR` and to forget them on success. 
- Change `buildTwigVariables` signature to `buildTwigVariables(AuthService $auth, string $mode)` and expose `registerUsername` plus an email fallback that uses consumed register values when rendering the register form. 
- Escape input values in the Twig macro by changing `value` to `value|e('html_attr')` and wire the register form partial to use the new `registerUsername` variable.
- Update `tests/AuthEntryControllerTest.php` to cover remembering, consumption, and HTML-escaping of remembered registration values.

### Testing
- Ran the updated `tests/AuthEntryControllerTest.php` suite which exercises `beginRegistration` scenarios and rendering behavior, and all assertions passed. 
- Verified that remembered values are written to session on validation/send errors and are consumed exactly once when rendering the register form. 
- Verified that remembered values are escaped in HTML attributes and do not break out of the `value` attribute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a634c2228ec8324b7893d16f7be6ae5)