### PR TITLE
Move generated usernames into UserService

### DIFF
--- a/public_html/src/Business/UserService.php
+++ b/public_html/src/Business/UserService.php
@@ -67,7 +67,8 @@ class UserService
     {
         $data = $this->userRepository->findByEmail($email);
         if ($data === false) {
-            $created = $this->userRepository->createUserByEmail($email, $ipAddress);
+            $username = bin2hex(openssl_random_pseudo_bytes(16));
+            $created = $this->userRepository->createUserByEmail($email, $ipAddress, $username);
         }
 
         if ($created === true) {

--- a/public_html/src/Data/Repository/UserRepository.php
+++ b/public_html/src/Data/Repository/UserRepository.php
@@ -47,10 +47,10 @@ class UserRepository
         return $this->dbh->table('user')->insert($userRecord);
     }
 
-    public function createUserByEmail(string $email, string $ipAddress): bool
+    public function createUserByEmail(string $email, string $ipAddress, string $username): bool
     {
         $userRecord = [
-            'username' => bin2hex(openssl_random_pseudo_bytes(16)),
+            'username' => $username,
             'email' => $email,
             'ip_address' => $ipAddress,
         ];


### PR DESCRIPTION
### Motivation

- Decouple username generation from the repository so the repository only inserts provided values.
- Preserve existing username generation behavior and avoid changing interfaces outside the direct service→repository call.

### Description

- Change `UserRepository::createUserByEmail()` signature to `createUserByEmail(string $email, string $ipAddress, string $username): bool` and use the provided `$username` when inserting.
- Update `UserService::createUserByEmail()` to generate the username before calling the repository using `bin2hex(openssl_random_pseudo_bytes(16))`, preserving the exact 16-byte then `bin2hex` behavior (32-character hex result).
- Only the call between `UserService` and `UserRepository` was updated, and no other files, interfaces, routes, or behaviors were changed.
- Files changed: `public_html/src/Data/Repository/UserRepository.php` and `public_html/src/Business/UserService.php`.

### Testing

- Ran `composer test` and all tests passed.
- Ran `php -l` on `public_html/src/Data/Repository/UserRepository.php` and `public_html/src/Business/UserService.php` with no syntax errors.
- Ran `git diff --check` with no issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6494dbf1d083249f279ee93fadd0e2)