### PR TITLE
Use standard output for migration console messages

### DIFF
--- a/public_html/app/Middleware/Migration.php
+++ b/public_html/app/Middleware/Migration.php
@@ -26,7 +26,7 @@ class Migration implements MigrationInterface
 
     public function log(string $message): void
     {
-        print_r($message . PHP_EOL);
+        fwrite(STDOUT, $message . PHP_EOL);
     }
 
     protected function execute(string $sql): void

--- a/public_html/app/Middleware/MigrationPipeline.php
+++ b/public_html/app/Middleware/MigrationPipeline.php
@@ -35,7 +35,7 @@ class MigrationPipeline
     {
         $tables = $this->collectTables();
         if ($this->dataPreserver->backup($tables) === true) {
-            print_r('Database snapshot stored successfully.' . PHP_EOL);
+            fwrite(STDOUT, 'Database snapshot stored successfully.' . PHP_EOL);
         }
 
         foreach (array_reverse($this->migrations) as $migration) {

--- a/public_html/app/console.php
+++ b/public_html/app/console.php
@@ -16,19 +16,19 @@ $migrationManager->addMigration(new \src\Migration\CreateUserEmailChange($dbh));
 
 $allowedArgs = ['--migrate', '--rollback', '-m', '-r'];
 if (isset($argv[1]) === false || in_array($argv[1], $allowedArgs) === false) {
-    print_r("Invalid command. Use '-m = --migrate' or '-r = --rollback'." . PHP_EOL);
+    fwrite(STDOUT, "Invalid command. Use '-m = --migrate' or '-r = --rollback'." . PHP_EOL);
 }
 
 if (isset($argv[1]) === true) {
     $mArgs = [$allowedArgs[0], $allowedArgs[2]];
     if (in_array($argv[1], $mArgs) === true) {
         $migrationManager->migrate();
-        print_r("Migrations applied successfully." . PHP_EOL);
+        fwrite(STDOUT, "Migrations applied successfully." . PHP_EOL);
     }
 
     $rArgs = [$allowedArgs[1], $allowedArgs[3]];
     if (in_array($argv[1], $rArgs) === true) {
         $migrationManager->rollback();
-        print_r("Migrations rolled back successfully." . PHP_EOL);
+        fwrite(STDOUT, "Migrations rolled back successfully." . PHP_EOL);
     }
 }


### PR DESCRIPTION
### Motivation
- Replace informal `print_r` console output with explicit writes to standard output for clearer, consistent CLI messaging during migrations.

### Description
- Replaced `print_r(...)` with `fwrite(STDOUT, ...)` in the migration CLI entrypoint `public_html/app/console.php` for invalid-command, migrate-success, and rollback-success messages.
- Replaced `print_r(...)` with `fwrite(STDOUT, ...)` in `public_html/app/Middleware/MigrationPipeline.php` for the database snapshot confirmation message.
- Replaced `print_r(...)` with `fwrite(STDOUT, ...)` in `public_html/app/Middleware/Migration.php` inside the `log()` method to route migration logs to stdout.

### Testing
- Linted modified files with `php -l public_html/app/console.php`, `php -l public_html/app/Middleware/MigrationPipeline.php`, and `php -l public_html/app/Middleware/Migration.php`, and all reported no syntax errors.
- Executed the project test scripts `for test in public_html/tests/*Test.php; do php "$test" || exit; done`, and all tests passed (including `QueryBuilder SQL generation tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64fd85ab488324b059b3da7468a42a)