### PR TITLE
Route auth entry actions through shared controller

### DIFF
--- a/public_html/src/Controller/AuthEntryController.php
+++ b/public_html/src/Controller/AuthEntryController.php
@@ -17,6 +17,16 @@ class AuthEntryController extends Controller
 
     private ?string $authorizationHeader = null;
 
+    public function login(Request $request): Response
+    {
+        return $this->handle($request, self::MODE_LOGIN);
+    }
+
+    public function register(Request $request): Response
+    {
+        return $this->handle($request, self::MODE_REGISTER);
+    }
+
     public function handle(Request $request, string $mode): Response
     {
         $this->assertValidMode($mode);
@@ -64,13 +74,13 @@ class AuthEntryController extends Controller
     private function handleFirstStep(Request $request, AuthService $auth, string $mode): ?Response
     {
         if ($mode === self::MODE_LOGIN) {
-            return $this->login($request, $auth);
+            return $this->handleLoginFirstStep($request, $auth);
         }
 
-        return $this->register($request, $auth);
+        return $this->handleRegisterFirstStep($request, $auth);
     }
 
-    private function login(Request $request, AuthService $auth): ?Response
+    private function handleLoginFirstStep(Request $request, AuthService $auth): ?Response
     {
         $submit = $request->post('submit_login');
         $email = $request->post('email');
@@ -84,7 +94,7 @@ class AuthEntryController extends Controller
         return null;
     }
 
-    private function register(Request $request, AuthService $auth): ?Response
+    private function handleRegisterFirstStep(Request $request, AuthService $auth): ?Response
     {
         $submit = $request->post('submit_register');
         if ((bool) $submit !== true) {

--- a/public_html/src/resources/routes.yaml
+++ b/public_html/src/resources/routes.yaml
@@ -11,12 +11,12 @@ setLocale:
 
 login:
     path: /login
-    controller: Login
+    controller: AuthEntryController::login
     methods: ['GET', 'HEAD', 'POST']
 
 register:
     path: /register
-    controller: Register
+    controller: AuthEntryController::register
     methods: ['GET', 'HEAD', 'POST']
 
 account:


### PR DESCRIPTION
### Motivation
- Allow the `/login` and `/register` routes to invoke the existing shared auth entry handler directly so routing can target explicit controller actions while keeping existing behavior intact.

### Description
- Added public `login(Request $request): Response` and `register(Request $request): Response` methods to `public_html/src/Controller/AuthEntryController.php` that delegate to `handle` with `self::MODE_LOGIN` and `self::MODE_REGISTER` respectively.
- Renamed the private first-step helpers to `handleLoginFirstStep` and `handleRegisterFirstStep` and updated uses in `handle` to avoid naming conflicts.
- Updated `public_html/src/resources/routes.yaml` to point the `login` route to `AuthEntryController::login` and the `register` route to `AuthEntryController::register` without changing paths or allowed methods.
- Left the existing proxy controllers `public_html/src/Controller/Login.php` and `public_html/src/Controller/Register.php` unchanged.

### Testing
- Ran `composer test` which executed `AuthEntryControllerTest`, `AuthEntryServiceTest`, `CsrfMiddlewareTest`, and `QueryBuilderSqlGenerationTest`, and all tests passed.
- Ran `php -l public_html/src/Controller/AuthEntryController.php` for syntax checking and it reported no syntax errors.
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a650909b9e08324ab5a08aa16da2c89)