### PR TITLE
Use registered JWT service in auth middleware

### DIFF
--- a/public_html/app/Middleware/AuthSessionJWT.php
+++ b/public_html/app/Middleware/AuthSessionJWT.php
@@ -25,7 +25,11 @@ class AuthSessionJWT
             return $next($request);
         }
 
-        $jwtService = new JWTService($this->application);
+        $jwtService = $this->application->get('jwtService');
+        if (($jwtService instanceof JWTService) === false) {
+            throw new \RuntimeException('jwtService service is not available.');
+        }
+
         $authorizationResult = $jwtService->authorizeRequest($request);
         if ($authorizationResult instanceof Response) {
             return $authorizationResult;


### PR DESCRIPTION
### Motivation
- Reuse the application-registered `jwtService` in the auth middleware instead of constructing a new `JWTService` instance to align with the container-driven service registration and lifecycle.

### Description
- In `public_html/app/Middleware/AuthSessionJWT.php` replaced `new JWTService($this->application)` with `$this->application->get('jwtService')` and added a runtime `instanceof JWTService` validation that throws a `\RuntimeException` if the service is not available, while preserving the existing middleware flow and response behavior; only this file was modified.

### Testing
- Ran `php -l app/Middleware/AuthSessionJWT.php` with no syntax errors and executed `composer check` which ran the automated tests `AuthEntryControllerTest`, `AuthEntryServiceTest`, `CsrfMiddlewareTest`, and `QueryBuilderSqlGenerationTest`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a652ccc827c8324ac411bf8470f5d9d)