### PR TITLE
Use registered user service in AuthService

### DIFF
--- a/public_html/app/Service/AuthService.php
+++ b/public_html/app/Service/AuthService.php
@@ -69,7 +69,11 @@ class AuthService
             return null;
         }
 
-        $userService = new UserService($this->application);
+        $userService = $this->application->get('userService');
+        if (($userService instanceof UserService) === false) {
+            return null;
+        }
+
         return $userService->getUserById($userId);
     }
 


### PR DESCRIPTION
### Motivation
- Use the already-registered `userService` from the application container in `getAuthenticatedUser()` instead of constructing a new `UserService`, preserving the current `?User` return type and behavior.

### Description
- Updated `getAuthenticatedUser()` in `public_html/app/Service/AuthService.php` to call `$this->application->get('userService')`, verify the result is an instance of `UserService`, and return `null` if the service is unavailable or of the wrong type; no other files were modified.

### Testing
- Ran `git diff --check`, `php -l public_html/app/Service/AuthService.php`, and `composer check` (which executed the repository test scripts including `AuthEntryController`, `AuthEntryService`, `CSRF middleware`, and `QueryBuilder SQL generation` tests) and all checks/tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a652dee496c8324929c1400378c92bd)