### PR TITLE
Use the registered email service for email changes

### DIFF
--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -238,7 +238,13 @@ class Account extends Controller
         }
 
         $verificationUrl = WEB_ROOT . 'account/email/verify/' . $rawToken;
-        $emailService = new EmailService();
+        $emailService = $this->application->get('emailService');
+        if (($emailService instanceof EmailService) === false) {
+            $this->accountService->deletePendingEmailChanges($user->getId());
+            $this->accountMessages['errors'][] = __('account.email-change-error');
+            return;
+        }
+
         $emailSent = $emailService->sendEmailChangeVerification($user->getEmail(), $newEmail, $verificationUrl);
         if ($emailSent === false) {
             $this->accountService->deletePendingEmailChanges($user->getId());


### PR DESCRIPTION
### Motivation
- Stop constructing `EmailService` directly inside `handleEmailChange()` and instead use the already-registered `emailService` from the `Application` container, while routing any missing/invalid service through the existing email-change error path.

### Description
- In `public_html/src/Controller/Account.php` replaced `new EmailService()` with `$this->application->get('emailService')` and added an `instanceof EmailService` check that calls `createEmailChangeRequest` cleanup (`deletePendingEmailChanges`) and adds the existing `__('account.email-change-error')` message then returns when the service is unavailable or wrong type, preserving all other behavior.

### Testing
- Ran `git diff --check`, `php -l src/Controller/Account.php`, and `composer test`, and all checks/tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a652f586f5483248ad8b47f44141052)