### PR TITLE
Use registered UserService in account controller

### DIFF
--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -35,7 +35,12 @@ class Account extends Controller
     {
         parent::__construct($application);
         $this->accountService = new AccountService($application);
-        $this->userService = new UserService($application);
+        $userService = $application->get('userService');
+        if (($userService instanceof UserService) === false) {
+            throw new \RuntimeException('userService service is not available.');
+        }
+
+        $this->userService = $userService;
         $mfaService = $application->get('mfaTotpService');
         if (($mfaService instanceof MFATOTPService) === false) {
             throw new \RuntimeException('mfaTotpService service is not available.');


### PR DESCRIPTION
### Motivation

- The Account controller should use the already-registered `userService` from the `Application` container instead of constructing a new `UserService` instance to avoid duplicate wiring and respect the central container configuration.

### Description

- Replaced the manual construction `new UserService($application)` in `public_html/src/Controller/Account.php` with retrieval via `$application->get('userService')`.
- Added a runtime validation that the retrieved service `instanceof UserService` and throw a `\RuntimeException` if not available.
- Preserved all account lookup, redirect, username-change, email-change, and MFA behavior and changed only `public_html/src/Controller/Account.php`.

### Testing

- Ran `php -l public_html/src/Controller/Account.php` which reported no syntax errors.
- Ran `composer check` which executed the project tests and resulted in passing tests (`AuthEntryController`, `AuthEntryService`, `CSRF middleware`, and `QueryBuilder SQL generation`).
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6530fcd8c483249954eff640265437)