### PR TITLE
Centralize username validation and status-driven username updates in AccountService

### DIFF
--- a/public_html/src/Business/AccountService.php
+++ b/public_html/src/Business/AccountService.php
@@ -6,9 +6,16 @@ namespace src\Business;
 
 use src\Data\Repository\UserEmailChangeRepository;
 use src\Data\Repository\UserRepository;
+use src\Entity\User;
 
 class AccountService
 {
+    public const USERNAME_CHANGE_UPDATED = 'updated';
+    public const USERNAME_CHANGE_INVALID = 'invalid';
+    public const USERNAME_CHANGE_UNCHANGED = 'unchanged';
+    public const USERNAME_CHANGE_TAKEN = 'taken';
+    public const USERNAME_CHANGE_ERROR = 'error';
+
     public const EMAIL_CHANGE_CONFIRMED = 'success';
     public const EMAIL_CHANGE_INVALID = 'invalid';
     public const EMAIL_CHANGE_EXPIRED = 'expired';
@@ -25,9 +32,26 @@ class AccountService
         $this->emailChangeRepository = new UserEmailChangeRepository($dbh);
     }
 
-    public function changeUsername(int $userId, string $username): bool
+    public function changeUsername(User $user, string $username): string
     {
-        return $this->userRepository->updateUsername($userId, $username);
+        $username = trim($username);
+        if ((bool) preg_match('/^[A-Za-z0-9._-]{3,32}$/', $username) === false) {
+            return self::USERNAME_CHANGE_INVALID;
+        }
+
+        if (strcasecmp($username, $user->getUsername()) === 0) {
+            return self::USERNAME_CHANGE_UNCHANGED;
+        }
+
+        if ($this->isUsernameTaken($username, $user->getId()) === true) {
+            return self::USERNAME_CHANGE_TAKEN;
+        }
+
+        if ($this->userRepository->updateUsername($user->getId(), $username) === false) {
+            return self::USERNAME_CHANGE_ERROR;
+        }
+
+        return self::USERNAME_CHANGE_UPDATED;
     }
 
     public function changeEmail(int $userId, string $email): bool

--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -17,7 +17,6 @@ use src\Entity\User;
 
 class Account extends Controller
 {
-    private const USERNAME_PATTERN = '/^[A-Za-z0-9._-]{3,32}$/';
     private const EMAIL_CHANGE_TTL = 3600;
 
     private AccountService $accountService;
@@ -174,32 +173,26 @@ class Account extends Controller
             return $user;
         }
 
-        $username = trim((string) $request->post('username'));
-        if ((bool) preg_match(self::USERNAME_PATTERN, $username) === false) {
-            $this->accountMessages['errors'][] = __('account.username-invalid');
-            return $user;
-        }
+        $username = (string) $request->post('username');
+        $status = $this->accountService->changeUsername($user, $username);
 
-        if (strcasecmp($username, $user->getUsername()) === 0) {
-            $this->accountMessages['errors'][] = __('account.username-unchanged');
-            return $user;
-        }
-
-        if ($this->accountService->isUsernameTaken($username, $user->getId()) === true) {
-            $this->accountMessages['errors'][] = __('account.username-taken');
-            return $user;
-        }
-
-        $updated = $this->accountService->changeUsername($user->getId(), $username);
-        if ($updated === true) {
+        if ($status === AccountService::USERNAME_CHANGE_UPDATED) {
             $this->accountMessages['success'][] = __('account.username-updated');
             $refreshed = $this->userService->getUserById($user->getId());
             if ($refreshed instanceof User) {
                 return $refreshed;
             }
-        } else {
-            $this->accountMessages['errors'][] = __('account.username-error');
+
+            return $user;
         }
+
+        $messageKeys = [
+            AccountService::USERNAME_CHANGE_INVALID => 'account.username-invalid',
+            AccountService::USERNAME_CHANGE_UNCHANGED => 'account.username-unchanged',
+            AccountService::USERNAME_CHANGE_TAKEN => 'account.username-taken',
+            AccountService::USERNAME_CHANGE_ERROR => 'account.username-error',
+        ];
+        $this->accountMessages['errors'][] = __($messageKeys[$status] ?? 'account.username-error');
 
         return $user;
     }


### PR DESCRIPTION
### Motivation
- Centralize username validation and update logic inside the business layer so controller code is thinner and validation is consistent.
- Provide explicit outcome statuses for username change attempts so the controller can show accurate user-facing messages.

### Description
- Added `src\Entity\User` import and new status constants on `AccountService` (`USERNAME_CHANGE_*`) to represent detailed outcomes. 
- Reworked `AccountService::changeUsername` signature to `changeUsername(User $user, string $username): string` and implemented validation, unchanged check, uniqueness check via `isUsernameTaken`, repository update, and corresponding status returns. 
- Removed the username regex constant from the controller and replaced inline validation with a call to `AccountService::changeUsername`, mapping returned status constants to localized message keys. 
- Adjusted controller flow to refresh the `User` from `UserService` on success and to consolidate error message handling using the service status mapping.

### Testing
- Ran the automated test suite with `vendor/bin/phpunit`; test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6533d72ba483248439d53331bc86e8)