### PR TITLE
Extract email change request workflow into AccountService

### DIFF
--- a/public_html/src/Business/AccountService.php
+++ b/public_html/src/Business/AccountService.php
@@ -10,6 +10,8 @@ use src\Entity\User;
 
 class AccountService
 {
+    private const EMAIL_CHANGE_TTL = 3600;
+
     public const USERNAME_CHANGE_UPDATED = 'updated';
     public const USERNAME_CHANGE_INVALID = 'invalid';
     public const USERNAME_CHANGE_UNCHANGED = 'unchanged';
@@ -17,19 +19,30 @@ class AccountService
     public const USERNAME_CHANGE_ERROR = 'error';
 
     public const EMAIL_CHANGE_CONFIRMED = 'success';
+    public const EMAIL_CHANGE_REQUESTED = 'requested';
     public const EMAIL_CHANGE_INVALID = 'invalid';
+    public const EMAIL_CHANGE_SAME = 'same';
     public const EMAIL_CHANGE_EXPIRED = 'expired';
     public const EMAIL_CHANGE_CONFLICT = 'conflict';
+    public const EMAIL_CHANGE_ERROR = 'error';
 
     private UserRepository $userRepository;
 
     private UserEmailChangeRepository $emailChangeRepository;
+
+    private EmailService $emailService;
 
     public function __construct(\app\Container\Application $application)
     {
         $dbh = $application->get('dbh');
         $this->userRepository = new UserRepository($dbh);
         $this->emailChangeRepository = new UserEmailChangeRepository($dbh);
+        $emailService = $application->get('emailService');
+        if (($emailService instanceof EmailService) === false) {
+            throw new \RuntimeException('emailService service is not available.');
+        }
+
+        $this->emailService = $emailService;
     }
 
     public function changeUsername(User $user, string $username): string
@@ -57,6 +70,44 @@ class AccountService
     public function changeEmail(int $userId, string $email): bool
     {
         return $this->userRepository->updateEmail($userId, $email);
+    }
+
+    public function requestEmailChange(User $user, string $newEmail): string
+    {
+        $newEmail = trim($newEmail);
+        if (filter_var($newEmail, FILTER_VALIDATE_EMAIL) === false) {
+            return self::EMAIL_CHANGE_INVALID;
+        }
+
+        if (strcasecmp($newEmail, $user->getEmail()) === 0) {
+            return self::EMAIL_CHANGE_SAME;
+        }
+
+        if ($this->isEmailInUse($newEmail, $user->getId()) === true) {
+            return self::EMAIL_CHANGE_CONFLICT;
+        }
+
+        try {
+            $rawToken = bin2hex(random_bytes(32));
+        } catch (\Throwable $exception) {
+            return self::EMAIL_CHANGE_ERROR;
+        }
+
+        $tokenHash = hash('sha256', $rawToken);
+        $expiresAt = date('Y-m-d H:i:s', (time() + self::EMAIL_CHANGE_TTL));
+        $created = $this->createEmailChangeRequest($user->getId(), $newEmail, $tokenHash, $expiresAt);
+        if ($created === false) {
+            return self::EMAIL_CHANGE_ERROR;
+        }
+
+        $verificationUrl = WEB_ROOT . 'account/email/verify/' . $rawToken;
+        $emailSent = $this->emailService->sendEmailChangeVerification($user->getEmail(), $newEmail, $verificationUrl);
+        if ($emailSent === false) {
+            $this->deletePendingEmailChanges($user->getId());
+            return self::EMAIL_CHANGE_ERROR;
+        }
+
+        return self::EMAIL_CHANGE_REQUESTED;
     }
 
     public function isUsernameTaken(string $username, int $excludeUserId = 0): bool

--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -9,7 +9,6 @@ use app\Http\Request;
 use app\Http\Response;
 use app\Service\AuthService;
 use src\Business\AccountService;
-use src\Business\EmailService;
 use src\Business\MFATOTPService;
 use src\Business\TOTPEmailService;
 use src\Business\UserService;
@@ -17,8 +16,6 @@ use src\Entity\User;
 
 class Account extends Controller
 {
-    private const EMAIL_CHANGE_TTL = 3600;
-
     private AccountService $accountService;
 
     private UserService $userService;
@@ -204,53 +201,21 @@ class Account extends Controller
             return;
         }
 
-        $newEmail = trim((string) $request->post('new_email'));
-        if (filter_var($newEmail, FILTER_VALIDATE_EMAIL) === false) {
-            $this->accountMessages['errors'][] = __('account.email-change-invalid');
+        $newEmail = (string) $request->post('new_email');
+        $status = $this->accountService->requestEmailChange($user, $newEmail);
+
+        if ($status === AccountService::EMAIL_CHANGE_REQUESTED) {
+            $this->accountMessages['success'][] = __('account.email-change-requested');
             return;
         }
 
-        if (strcasecmp($newEmail, $user->getEmail()) === 0) {
-            $this->accountMessages['errors'][] = __('account.email-change-same');
-            return;
-        }
-
-        if ($this->accountService->isEmailInUse($newEmail, $user->getId()) === true) {
-            $this->accountMessages['errors'][] = __('account.email-change-conflict');
-            return;
-        }
-
-        try {
-            $rawToken = bin2hex(random_bytes(32));
-        } catch (\Throwable $exception) {
-            $this->accountMessages['errors'][] = __('account.email-change-error');
-            return;
-        }
-
-        $tokenHash = hash('sha256', $rawToken);
-        $expiresAt = date('Y-m-d H:i:s', (time() + self::EMAIL_CHANGE_TTL));
-        $created = $this->accountService->createEmailChangeRequest($user->getId(), $newEmail, $tokenHash, $expiresAt);
-        if ($created === false) {
-            $this->accountMessages['errors'][] = __('account.email-change-error');
-            return;
-        }
-
-        $verificationUrl = WEB_ROOT . 'account/email/verify/' . $rawToken;
-        $emailService = $this->application->get('emailService');
-        if (($emailService instanceof EmailService) === false) {
-            $this->accountService->deletePendingEmailChanges($user->getId());
-            $this->accountMessages['errors'][] = __('account.email-change-error');
-            return;
-        }
-
-        $emailSent = $emailService->sendEmailChangeVerification($user->getEmail(), $newEmail, $verificationUrl);
-        if ($emailSent === false) {
-            $this->accountService->deletePendingEmailChanges($user->getId());
-            $this->accountMessages['errors'][] = __('account.email-change-error');
-            return;
-        }
-
-        $this->accountMessages['success'][] = __('account.email-change-requested');
+        $messageKeys = [
+            AccountService::EMAIL_CHANGE_INVALID => 'account.email-change-invalid',
+            AccountService::EMAIL_CHANGE_SAME => 'account.email-change-same',
+            AccountService::EMAIL_CHANGE_CONFLICT => 'account.email-change-conflict',
+            AccountService::EMAIL_CHANGE_ERROR => 'account.email-change-error',
+        ];
+        $this->accountMessages['errors'][] = __($messageKeys[$status] ?? 'account.email-change-error');
     }
 
     private function getTotpEmailService(): TOTPEmailService


### PR DESCRIPTION
### Motivation

- Centralize the submitted email-change request workflow into the business service to keep controller logic minimal and preserve the exact validation, token creation, persistence, delivery, and cleanup semantics.
- Move email-change TTL and request status values into `AccountService` so the service fully owns request lifecycle semantics.

### Description

- Added `private const EMAIL_CHANGE_TTL = 3600` and new status constants `EMAIL_CHANGE_REQUESTED`, `EMAIL_CHANGE_SAME`, and `EMAIL_CHANGE_ERROR` to `public_html/src/Business/AccountService.php` and kept `EMAIL_CHANGE_CONFIRMED`, `EMAIL_CHANGE_INVALID`, `EMAIL_CHANGE_EXPIRED`, and `EMAIL_CHANGE_CONFLICT` intact.
- Introduced `public function requestEmailChange(User $user, string $newEmail): string` in `AccountService` which performs the original controller workflow in the exact order and behavior: trims the input, validates with `FILTER_VALIDATE_EMAIL`, compares to current email with `strcasecmp`, checks `isEmailInUse`, generates 32 random bytes and encodes with `bin2hex`, catches any `\Throwable` during token generation, stores only the SHA-256 token hash, uses a 3600-second expiration formatted as `Y-m-d H:i:s`, replaces the existing pending request via the existing repository behavior, builds the verification URL as `WEB_ROOT . 'account/email/verify/' . $rawToken`, sends the verification email to the user’s current email via the existing `EmailService`, deletes the pending request if email delivery fails, and returns the appropriate status constant.
- Obtained the registered `EmailService` from the existing `Application` inside `AccountService::__construct()` and stored it as a dependency used by `requestEmailChange()`.
- Simplified `public_html/src/Controller/Account.php` by keeping the `submit_email` check, passing the raw posted `new_email` value and the current `User` to `requestEmailChange()`, mapping returned statuses to the exact existing translation keys, emitting the existing success message only for the `requested` status, and using `account.email-change-error` as the fallback for unexpected statuses.
- Changes were limited to `public_html/src/Business/AccountService.php` and `public_html/src/Controller/Account.php` only, with no new files, DTOs, interfaces, or other structural changes.

### Testing

- Ran `git diff --check` with no reported issues.
- Performed PHP linting with `php -l public_html/src/Business/AccountService.php` and `php -l public_html/src/Controller/Account.php`, both reported no syntax errors.
- Executed `composer check` which ran the configured test scripts and reported the included tests passed (`AuthEntryController`, `AuthEntryService`, `CSRF middleware`, `QueryBuilder SQL generation`, and `AccountRedirectStatus` as shown by the composer output).
- Verified the modified files are staged/committed locally and the exact diff for the two changed files was produced and contains the additions and removals described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6538081e788324a730925b48d33f84)