### PR TITLE
Fix MFA setup email service lookup

### DIFF
--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -9,6 +9,7 @@ use app\Http\Request;
 use app\Http\Response;
 use app\Service\AuthService;
 use src\Business\AccountService;
+use src\Business\EmailService;
 use src\Business\MFATOTPService;
 use src\Business\TOTPEmailService;
 use src\Business\UserService;
@@ -248,7 +249,12 @@ class Account extends Controller
             $totpEmailService = $this->getTotpEmailService();
             $emailCode = $totpEmailService->generateEmailTOTPForSession($userId, $auth->getMfaSetupEmailSessionKey());
 
-            $emailService = new EmailService();
+            $emailService = $this->application->get('emailService');
+            if (($emailService instanceof EmailService) === false) {
+                $this->accountMessages['errors'][] = __('account.mfa-email-code-send-error');
+                return;
+            }
+
             $emailSent = $emailService->sendTOTPEmail($user->getEmail(), $emailCode);
             if ($emailSent === false) {
                 $this->accountMessages['errors'][] = __('account.mfa-email-code-send-error');


### PR DESCRIPTION
### Motivation
- Ensure the MFA setup/resend path uses the already-registered `emailService` from the application container instead of constructing a new `EmailService`, and follow the existing error path when the service is unavailable or the wrong type.

### Description
- Modified only `public_html/src/Controller/Account.php` to import `src\Business\EmailService` and replace `new EmailService()` with `$this->application->get('emailService')` and a type-check that uses the existing `account.mfa-email-code-send-error` error path when the service is missing or incorrect, while preserving pending-secret generation, email-TOTP generation, session state, recipient, and success/failure messages.

### Testing
- Ran `php -l public_html/src/Controller/Account.php` which reported no syntax errors; `composer check` which ran the test suite referenced by composer and reported passing checks; and `git diff --check` which produced no problems; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a65ad2698548324a3e98123cd561a26)