### PR TITLE
Require csrfService to be registered before CSRF middleware runs

### DIFF
--- a/public_html/app/Middleware/Csrf.php
+++ b/public_html/app/Middleware/Csrf.php
@@ -22,8 +22,7 @@ class Csrf
     {
         $csrf = $this->application->get('csrfService');
         if ($csrf instanceof CsrfService === false) {
-            $csrf = new CsrfService($this->application->get('sessionService'));
-            $this->application->addService('csrfService', $csrf);
+            throw new \RuntimeException('The csrfService must be registered before the CSRF middleware runs.');
         }
 
         if ($csrf->isStateChangingMethod($request->getMethod()) === true && $csrf->isValidRequest($request) === false) {

--- a/public_html/tests/CsrfMiddlewareTest.php
+++ b/public_html/tests/CsrfMiddlewareTest.php
@@ -147,6 +147,18 @@ function assertSameValue(mixed $expected, mixed $actual, string $message): void
     }
 }
 
+function assertThrowsRuntimeException(callable $callback, string $expectedMessage, string $message): void
+{
+    try {
+        $callback();
+    } catch (RuntimeException $exception) {
+        assertSameValue($expectedMessage, $exception->getMessage(), $message);
+        return;
+    }
+
+    throw new RuntimeException($message . ' Expected RuntimeException to be thrown.');
+}
+
 function runThroughCsrf(CsrfTestApplication $application, Request $request): Response
 {
     $middleware = new Csrf($application);
@@ -169,6 +181,13 @@ $application = makeCsrfApplication($session);
 $response = runThroughCsrf($application, new CsrfTestRequest('GET'));
 assertSameValue(204, $response->getStatusCode(), 'Safe requests should pass without a token.');
 assertSameValue('passed', $response->getContent(), 'Safe requests should continue to the next handler.');
+
+$application = new CsrfTestApplication();
+assertThrowsRuntimeException(
+    static fn () => runThroughCsrf($application, new CsrfTestRequest('GET')),
+    'The csrfService must be registered before the CSRF middleware runs.',
+    'CSRF middleware should require the service registered by session middleware.'
+);
 
 $session = new CsrfTestSession();
 $application = makeCsrfApplication($session);


### PR DESCRIPTION
### Motivation
- Prevent the CSRF middleware from implicitly creating its own `CsrfService` and instead require the application to register the service beforehand.
- Make failure mode explicit so missing middleware/service registration is detected early with a clear error.

### Description
- The middleware now throws a `RuntimeException` if `csrfService` is not present in the application container instead of instantiating and registering one automatically.
- Added `assertThrowsRuntimeException` helper to the tests and a test case that verifies the middleware raises the expected exception when `csrfService` is not registered.
- Existing CSRF behavior and responses for safe methods, invalid tokens, JSON responses, and valid tokens remain unchanged.

### Testing
- Ran the updated `CsrfMiddlewareTest.php` suite which includes the new exception test and existing tests for GET/POST/DELETE handling, and all tests passed.
- Verified JSON CSRF failure contains `error` and `message` and that valid form/header tokens are accepted by the middleware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a65aff9b9e08324abba5ba43d394e94)