### PR TITLE
Register AccountService in the application container

### DIFF
--- a/public_html/app/Container/Application.php
+++ b/public_html/app/Container/Application.php
@@ -7,6 +7,7 @@ namespace app\Container;
 use app\Http\Router;
 use app\Service\JWTService;
 use app\Service\SessionService;
+use src\Business\AccountService;
 use src\Business\AuthEntryService;
 use src\Business\EmailService;
 use src\Business\MFATOTPService;
@@ -38,6 +39,7 @@ class Application extends Container
         $this->addService('dbh', fn(): Connection => new Connection());
         $this->addService('router', $this->router = new Router());
         $this->addService('translationService', new \app\Service\TranslationService());
+        $this->addService('accountService', fn(): AccountService => new AccountService($this));
         $this->addService('userService', fn(): UserService => new UserService($this));
         $this->addService('totpService', fn(): TOTPService => new TOTPService());
         $this->addService('userMfaTotpRepository', fn(): UserMFATOTPRepository => new UserMFATOTPRepository(

--- a/public_html/src/Controller/Account.php
+++ b/public_html/src/Controller/Account.php
@@ -31,7 +31,12 @@ class Account extends Controller
     public function __construct(Application $application)
     {
         parent::__construct($application);
-        $this->accountService = new AccountService($application);
+        $accountService = $application->get('accountService');
+        if (($accountService instanceof AccountService) === false) {
+            throw new \RuntimeException('accountService service is not available.');
+        }
+
+        $this->accountService = $accountService;
         $userService = $application->get('userService');
         if (($userService instanceof UserService) === false) {
             throw new \RuntimeException('userService service is not available.');


### PR DESCRIPTION
### Motivation
- Consolidate `AccountService` construction into the application container so controllers can reuse a single, lazily-created service instance.
- Preserve the exact construction `new AccountService($this)` while enabling DI-style retrieval from the container.
- Ensure the account controller validates the retrieved service and fails with the project-style exception when unavailable.

### Description
- Added `use src\Business\AccountService;` and registered a lazy `accountService` in `public_html/app/Container/Application.php` using `fn(): AccountService => new AccountService($this)`.
- Replaced direct construction in `public_html/src/Controller/Account.php` with retrieval via `$application->get('accountService')` and an `instanceof` check.
- Threw the project-style `\RuntimeException` when the `accountService` lookup returns an unavailable or incorrect type.
- Limited changes to only `public_html/app/Container/Application.php` and `public_html/src/Controller/Account.php` as requested.

### Testing
- Ran `git diff --check` with no issues reported, and committed the changes successfully.
- Ran `php -l app/Container/Application.php` and `php -l src/Controller/Account.php`, both reported no syntax errors.
- Ran `composer check`, which executed the project checks and reported passing tests (including AuthEntryController, AuthEntryService, CSRF middleware, and QueryBuilder SQL generation checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a65b41081348324bf03a55e62aa9f1d)